### PR TITLE
Replaces .project_id with .id to identify the project id value

### DIFF
--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -20,7 +20,7 @@ resource "dbtcloud_environment" "test_environment" {
   // the dbt_version is always major.minor.0-latest or major.minor.0-pre
   dbt_version   = "1.5.0-latest"
   name          = "test"
-  project_id    = data.dbt_cloud_project.test_project.project_id
+  project_id    = data.dbt_cloud_project.test_project.id
   type          = "deployment"
   credential_id = dbt_cloud_snowflake_credential.new_credential.credential_id
 }

--- a/docs/resources/snowflake_credential.md
+++ b/docs/resources/snowflake_credential.md
@@ -17,7 +17,7 @@ description: |-
 // legacy names will be removed from 0.3 onwards
 
 resource "dbtcloud_snowflake_credential" "new_credential" {
-  project_id  = data.dbt_cloud_project.test_project.project_id
+  project_id  = data.dbt_cloud_project.test_project.id
   auth_type   = "password"
   num_threads = 16
   schema      = "SCHEMA"

--- a/examples/resources/dbtcloud_environment/resource.tf
+++ b/examples/resources/dbtcloud_environment/resource.tf
@@ -5,7 +5,7 @@ resource "dbtcloud_environment" "test_environment" {
   // the dbt_version is always major.minor.0-latest or major.minor.0-pre
   dbt_version   = "1.5.0-latest"
   name          = "test"
-  project_id    = data.dbt_cloud_project.test_project.project_id
+  project_id    = data.dbt_cloud_project.test_project.id
   type          = "deployment"
   credential_id = dbt_cloud_snowflake_credential.new_credential.credential_id
 }

--- a/examples/resources/dbtcloud_snowflake_credential/resource.tf
+++ b/examples/resources/dbtcloud_snowflake_credential/resource.tf
@@ -2,7 +2,7 @@
 // legacy names will be removed from 0.3 onwards
 
 resource "dbtcloud_snowflake_credential" "new_credential" {
-  project_id  = data.dbt_cloud_project.test_project.project_id
+  project_id  = data.dbt_cloud_project.test_project.id
   auth_type   = "password"
   num_threads = 16
   schema      = "SCHEMA"


### PR DESCRIPTION
Updating documentation to reflect what project id identifier should be.

An error popped with when I plan the resource dbtcloud_snowflake_credential following its [documentation](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest/docs/resources/snowflake_credential) as follows:

│ Error: Unsupported attribute
│ 
│   on credentials.tf line 2, in resource "dbtcloud_snowflake_credential" "test":
│    2:   project_id  = dbtcloud_project.test.**project_id**

Looking at the [dbtcloud_project documentation](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest/docs/resources/project), it should be just `id`
