### PR TITLE
fix: Update GetGroup function to get by id rather than list and find

### DIFF
--- a/pkg/dbt_cloud/group.go
+++ b/pkg/dbt_cloud/group.go
@@ -45,7 +45,7 @@ type GroupPermissionListResponse struct {
 }
 
 func (c *Client) GetGroup(groupID int) (*Group, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v3/accounts/%s/groups/", c.HostURL, strconv.Itoa(c.AccountID)), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v3/accounts/%s/groups/%s/", c.HostURL, strconv.Itoa(c.AccountID), strconv.Itoa(groupID)), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -55,19 +55,13 @@ func (c *Client) GetGroup(groupID int) (*Group, error) {
 		return nil, err
 	}
 
-	groupListResponse := GroupListResponse{}
-	err = json.Unmarshal(body, &groupListResponse)
+	groupResponse := GroupResponse{}
+	err = json.Unmarshal(body, &groupResponse)
 	if err != nil {
 		return nil, err
 	}
 
-	for i, group := range groupListResponse.Data {
-		if *group.ID == groupID {
-			return &groupListResponse.Data[i], nil
-		}
-	}
-
-	return nil, fmt.Errorf("resource-not-found: Group with ID %d not found", groupID)
+	return &groupResponse.Data, nil
 }
 
 func (c *Client) CreateGroup(name string, assignByDefault bool, ssoMappingGroups []string) (*Group, error) {


### PR DESCRIPTION
We found that once you get over 100 groups in DBT, the GetGroup function was failing to find some group. This is because the function uses the list endpoint, which is paged and defaults to 100 groups as the limit to return.

This PR adjusts the function to use the Retrieve Group endpoint: https://docs.getdbt.com/dbt-cloud/api-v3#/operations/Retrieve%20Group

For some reason, the API docs say data returns as a list but actually testing it, it came back as a JSON. #shrug, I think it's probably a doc that just needs updating.