### PR TITLE
Fix typo in examples for fabric credential

### DIFF
--- a/docs/resources/fabric_credential.md
+++ b/docs/resources/fabric_credential.md
@@ -14,7 +14,7 @@ description: |-
 
 ```terraform
 # when using AD authentication
-resource "dbtcloud_databricks_credential" "my_databricks_cred" {
+resource "dbtcloud_fabric_credential" "my_fabric_cred_ad" {
   project_id           = dbtcloud_project.dbt_project.id
   adapter_id           = dbtcloud_fabric_connection.my_fabric_connection.adapter_id
   schema               = "my_schema"
@@ -24,7 +24,7 @@ resource "dbtcloud_databricks_credential" "my_databricks_cred" {
 }
 
 # when using service principal authentication
-resource "dbtcloud_databricks_credential" "my_spark_cred" {
+resource "dbtcloud_fabric_credential" "my_fabric_cred_serv_princ" {
   project_id           = dbtcloud_project.dbt_project.id
   adapter_id           = dbtcloud_fabric_connection.my_fabric_connection.adapter_id
   schema               = "my_schema"

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -13,7 +13,6 @@ description: |-
 Those improvements include modifications to deferral which was historically set at the job level and will now be set at the environment level. 
 Deferral can still be set to "self" by setting `self_deferring` to `true` but with the new approach, deferral to other runs need to be done with `deferring_environment_id` instead of `deferring_job_id`.
 
-
 ~> As of beginning of February 2024, job chaining with `job_completion_trigger_condition` is in private beta and not available to all users.
 <br/>
 <br/>
@@ -116,7 +115,7 @@ resource "dbtcloud_job" "downstream_job" {
 - `execute_steps` (List of String) List of commands to execute for the job
 - `name` (String) Job name
 - `project_id` (Number) Project ID to create the job in
-- `triggers` (Map of Boolean) Flags for which types of triggers to use, possible values are `github_webhook`, `git_provider_webhook`, `schedule` and `custom_branch_only`. <br>`custom_branch_only` is only relevant for CI jobs triggered automatically on PR creation to only trigger a job on a PR to the custom branch of the environment. To create a job in a 'deactivated' state, set all to `false`.
+- `triggers` (Map of Boolean) Flags for which types of triggers to use, the values are `github_webhook`, `git_provider_webhook`, `schedule` and `custom_branch_only`. <br>`custom_branch_only` is only relevant for CI jobs triggered automatically on PR creation to only trigger a job on a PR to the custom branch of the environment. To create a job in a 'deactivated' state, set all to `false`.
 
 ### Optional
 

--- a/examples/resources/dbtcloud_fabric_credential/resource.tf
+++ b/examples/resources/dbtcloud_fabric_credential/resource.tf
@@ -1,5 +1,5 @@
 # when using AD authentication
-resource "dbtcloud_databricks_credential" "my_databricks_cred" {
+resource "dbtcloud_fabric_credential" "my_fabric_cred_ad" {
   project_id           = dbtcloud_project.dbt_project.id
   adapter_id           = dbtcloud_fabric_connection.my_fabric_connection.adapter_id
   schema               = "my_schema"
@@ -9,7 +9,7 @@ resource "dbtcloud_databricks_credential" "my_databricks_cred" {
 }
 
 # when using service principal authentication
-resource "dbtcloud_databricks_credential" "my_spark_cred" {
+resource "dbtcloud_fabric_credential" "my_fabric_cred_serv_princ" {
   project_id           = dbtcloud_project.dbt_project.id
   adapter_id           = dbtcloud_fabric_connection.my_fabric_connection.adapter_id
   schema               = "my_schema"


### PR DESCRIPTION
Skipping CI as those changes are just docs one