### PR TITLE
Prepare release 0.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.2.20...HEAD)
+## [Unreleased](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.2.21...HEAD)
+
+## [0.2.21](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.2.20...v0.2.21)
+
+## Changes
+
+- Flag `fetch_deploy_key` as deprecated for `dbtcloud_repository`. The key is always fetched for the genetic git clone approach
+
+## Documentations
+
+- Add info about `versionless` dbt environment (Private Beta)
+- [#235](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/235) Fix docs on the examples for Fabric credentials
 
 ## [0.2.20](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.2.19...v0.2.20)
 

--- a/docs/data-sources/repository.md
+++ b/docs/data-sources/repository.md
@@ -22,7 +22,7 @@ description: |-
 
 ### Optional
 
-- `fetch_deploy_key` (Boolean) Whether we should return the public deploy key
+- `fetch_deploy_key` (Boolean, Deprecated) Whether we should return the public deploy key
 
 ### Read-Only
 

--- a/docs/guides/1_getting_started.md
+++ b/docs/guides/1_getting_started.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     dbtcloud = {
       source  = "dbt-labs/dbtcloud"
-      version = "0.2.2"
+      version = "0.2.20"
     }
   }
 }

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -18,7 +18,7 @@ description: |-
 // legacy names will be removed from 0.3 onwards
 
 resource "dbtcloud_environment" "ci_environment" {
-  // the dbt_version is always major.minor.0-latest or major.minor.0-pre
+  // the dbt_version is major.minor.0-latest , major.minor.0-pre or versionless (Beta on 15 Feb 2024, to always be on the latest dbt version)
   dbt_version   = "1.6.0-latest"
   name          = "CI"
   project_id    = dbtcloud_project.dbt_project.id
@@ -50,7 +50,7 @@ resource "dbtcloud_environment" "dev_environment" {
 
 ### Required
 
-- `dbt_version` (String) Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` or `major.minor.0-pre`, e.g. `1.5.0-latest`
+- `dbt_version` (String) Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre` or `versionless`. In a future version of the provider `versionless` will be the default if no version is provided
 - `name` (String) Environment name
 - `project_id` (Number) Project ID to create the environment in
 - `type` (String) The type of environment (must be either development or deployment)

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -106,7 +106,7 @@ resource "dbtcloud_repository" "ado_repo" {
 - `azure_active_directory_project_id` (String) The Azure Dev Ops project ID. It can be retrieved via the Azure API or using the data source `dbtcloud_azure_dev_ops_project` and the project name - (for ADO native integration only)
 - `azure_active_directory_repository_id` (String) The Azure Dev Ops repository ID. It can be retrieved via the Azure API or using the data source `dbtcloud_azure_dev_ops_repository` along with the ADO Project ID and the repository name - (for ADO native integration only)
 - `azure_bypass_webhook_registration_failure` (Boolean) If set to False (the default), the connection will fail if the service user doesn't have access to set webhooks (required for auto-triggering CI jobs). If set to True, the connection will be successful but no automated CI job will be triggered - (for ADO native integration only)
-- `fetch_deploy_key` (Boolean) Whether we should return the public deploy key - (for the `deploy_key` strategy)
+- `fetch_deploy_key` (Boolean, Deprecated) Whether we should return the public deploy key - (for the `deploy_key` strategy)
 - `git_clone_strategy` (String) Git clone strategy for the repository. Can be `deploy_key` (default) for cloning via SSH Deploy Key, `github_app` for GitHub native integration, `deploy_token` for the GitLab native integration and `azure_active_directory_app` for ADO native integration
 - `github_installation_id` (Number) Identifier for the GitHub App - (for GitHub native integration only)
 - `gitlab_project_id` (Number) Identifier for the Gitlab project -  (for GitLab native integration only)

--- a/examples/resources/dbtcloud_environment/resource.tf
+++ b/examples/resources/dbtcloud_environment/resource.tf
@@ -3,7 +3,7 @@
 // legacy names will be removed from 0.3 onwards
 
 resource "dbtcloud_environment" "ci_environment" {
-  // the dbt_version is always major.minor.0-latest or major.minor.0-pre
+  // the dbt_version is major.minor.0-latest , major.minor.0-pre or versionless (Beta on 15 Feb 2024, to always be on the latest dbt version)
   dbt_version   = "1.6.0-latest"
   name          = "CI"
   project_id    = dbtcloud_project.dbt_project.id

--- a/guides/1_getting_started.md
+++ b/guides/1_getting_started.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     dbtcloud = {
       source  = "dbt-labs/dbtcloud"
-      version = "0.2.2"
+      version = "0.2.20"
     }
   }
 }

--- a/pkg/data_sources/repository.go
+++ b/pkg/data_sources/repository.go
@@ -25,6 +25,7 @@ var repositorySchema = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     false,
+		Deprecated:  "This field is deprecated and will be removed in a future version of the provider. The key is always fetched when the clone strategy is `deploy_key`",
 		Description: "Whether we should return the public deploy key",
 	},
 	"is_active": &schema.Schema{
@@ -71,16 +72,22 @@ func DatasourceRepository() *schema.Resource {
 	}
 }
 
-func datasourceRepositoryRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func datasourceRepositoryRead(
+	ctx context.Context,
+	d *schema.ResourceData,
+	m interface{},
+) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
 	var diags diag.Diagnostics
 
 	repositoryID := d.Get("repository_id").(int)
 	projectID := d.Get("project_id").(int)
-	fetchDeployKey := d.Get("fetch_deploy_key").(bool)
 
-	repository, err := c.GetRepository(strconv.Itoa(repositoryID), strconv.Itoa(projectID), fetchDeployKey)
+	repository, err := c.GetRepository(
+		strconv.Itoa(repositoryID),
+		strconv.Itoa(projectID),
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/dbt_cloud/repository.go
+++ b/pkg/dbt_cloud/repository.go
@@ -43,7 +43,6 @@ type RepositoryResponse struct {
 
 func (c *Client) GetRepository(
 	repositoryID, projectID string,
-	fetch_deploy_key bool,
 ) (*Repository, error) {
 
 	repositoryUrl := fmt.Sprintf(
@@ -53,9 +52,6 @@ func (c *Client) GetRepository(
 		projectID,
 		repositoryID,
 	)
-	if fetch_deploy_key {
-		repositoryUrl += "?include_related['deploy_key']"
-	}
 
 	req, err := http.NewRequest("GET", repositoryUrl, nil)
 	if err != nil {

--- a/pkg/resources/environment.go
+++ b/pkg/resources/environment.go
@@ -44,7 +44,7 @@ func ResourceEnvironment() *schema.Resource {
 			"dbt_version": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` or `major.minor.0-pre`, e.g. `1.5.0-latest`",
+				Description: "Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre` or `versionless`. In a future version of the provider `versionless` will be the default if no version is provided",
 			},
 			"type": &schema.Schema{
 				Type:        schema.TypeString,
@@ -59,7 +59,14 @@ func ResourceEnvironment() *schema.Resource {
 						"deployment":
 						return
 					}
-					errs = append(errs, fmt.Errorf("%q must be either development or deployment, got: %q", key, type_))
+					errs = append(
+						errs,
+						fmt.Errorf(
+							"%q must be either development or deployment, got: %q",
+							key,
+							type_,
+						),
+					)
 					return
 				},
 			},
@@ -99,7 +106,11 @@ func ResourceEnvironment() *schema.Resource {
 	}
 }
 
-func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEnvironmentCreate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	m interface{},
+) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
 	var diags diag.Diagnostics
@@ -115,7 +126,18 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, m in
 	deploymentType := d.Get("deployment_type").(string)
 	extendedAttributesID := d.Get("extended_attributes_id").(int)
 
-	environment, err := c.CreateEnvironment(isActive, projectId, name, dbtVersion, type_, useCustomBranch, customBranch, credentialId, deploymentType, extendedAttributesID)
+	environment, err := c.CreateEnvironment(
+		isActive,
+		projectId,
+		name,
+		dbtVersion,
+		type_,
+		useCustomBranch,
+		customBranch,
+		credentialId,
+		deploymentType,
+		extendedAttributesID,
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -127,7 +149,11 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, m in
 	return diags
 }
 
-func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEnvironmentRead(
+	ctx context.Context,
+	d *schema.ResourceData,
+	m interface{},
+) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
 	var diags diag.Diagnostics
@@ -188,7 +214,11 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, m inte
 	return diags
 }
 
-func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEnvironmentUpdate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	m interface{},
+) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
 	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
@@ -269,7 +299,11 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, m in
 	return resourceEnvironmentRead(ctx, d, m)
 }
 
-func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEnvironmentDelete(
+	ctx context.Context,
+	d *schema.ResourceData,
+	m interface{},
+) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
 	var diags diag.Diagnostics

--- a/pkg/resources/repository.go
+++ b/pkg/resources/repository.go
@@ -91,6 +91,7 @@ func ResourceRepository() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 				Description: "Whether we should return the public deploy key - (for the `deploy_key` strategy)",
+				Deprecated:  "This field is deprecated and will be removed in a future version of the provider, please remove it from your configuration. The key is always fetched when the clone strategy is `deploy_key`",
 			},
 			"deploy_key": &schema.Schema{
 				Type:        schema.TypeString,
@@ -157,9 +158,8 @@ func resourceRepositoryRead(
 
 	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
 	repositoryIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
-	fetchDeployKey := d.Get("fetch_deploy_key").(bool)
 
-	repository, err := c.GetRepository(repositoryIdString, projectIdString, fetchDeployKey)
+	repository, err := c.GetRepository(repositoryIdString, projectIdString)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "resource-not-found") {
 			d.SetId("")
@@ -219,10 +219,9 @@ func resourceRepositoryUpdate(
 
 	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
 	repositoryIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
-	fetchDeployKey := d.Get("fetch_deploy_key").(bool)
 
 	if d.HasChange("is_active") {
-		repository, err := c.GetRepository(repositoryIdString, projectIdString, fetchDeployKey)
+		repository, err := c.GetRepository(repositoryIdString, projectIdString)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/repository_acceptance_test.go
+++ b/pkg/resources/repository_acceptance_test.go
@@ -134,6 +134,7 @@ resource "dbtcloud_project" "test_project" {
 resource "dbtcloud_repository" "test_repository_github" {
   remote_url = "%s"
   project_id = dbtcloud_project.test_project.id
+  fetch_deploy_key = true
   depends_on = [dbtcloud_project.test_project]
 }
 `, projectName, repoUrl)
@@ -182,7 +183,7 @@ func testAccCheckDbtCloudRepositoryExists(resource string) resource.TestCheckFun
 		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
 		repositoryId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1]
 
-		_, err := apiClient.GetRepository(repositoryId, projectId, false)
+		_, err := apiClient.GetRepository(repositoryId, projectId)
 		if err != nil {
 			return fmt.Errorf("error fetching item with resource %s. %s", resource, err)
 		}
@@ -200,7 +201,7 @@ func testAccCheckDbtCloudRepositoryDestroy(s *terraform.State) error {
 		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
 		repositoryId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1]
 
-		_, err := apiClient.GetRepository(repositoryId, projectId, false)
+		_, err := apiClient.GetRepository(repositoryId, projectId)
 		if err == nil {
 			return fmt.Errorf("Repository still exists")
 		}


### PR DESCRIPTION
- Add info about `versionless` dbt environment (Private Beta)
- Flag `fetch_deploy_key` as deprecated for `dbtcloud_repository`. The key is always fetched for the genetic git clone approach