### PR TITLE
docs: example - how to fail during apply when a service token is used…

### DIFF
--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -64,6 +64,7 @@ resource "dbtcloud_repository" "github_repo_other" {
 
 ### repo cloned via the GitLab integration
 # as of 15 Sept 2023 this resource requires using a user token and can't be set with a service token - CC-791
+# for better clarity, you can add a null_resource with precondition to throw an error during apply if the repository is created with a service token
 resource "dbtcloud_repository" "gitlab_repo" {
   project_id         = dbtcloud_project.dbt_project.id
   remote_url         = "<gitlab-group>/<gitlab-project>"
@@ -71,6 +72,14 @@ resource "dbtcloud_repository" "gitlab_repo" {
   git_clone_strategy = "deploy_token"
 }
 
+resource "null_resource" "check_repository" {
+  lifecycle {
+    precondition {
+      condition     = dbtcloud_repository.gitlab_repo.repository_credentials_id != 0
+      error_message = "Repositories created with a service token are currently not working properly (https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/192)"
+    }
+  }
+}
 
 ### repo cloned via the deploy token strategy
 resource "dbtcloud_repository" "deploy_repo" {

--- a/examples/resources/dbtcloud_repository/resource.tf
+++ b/examples/resources/dbtcloud_repository/resource.tf
@@ -36,6 +36,7 @@ resource "dbtcloud_repository" "github_repo_other" {
 
 ### repo cloned via the GitLab integration
 # as of 15 Sept 2023 this resource requires using a user token and can't be set with a service token - CC-791
+# for better clarity, you can add a null_resource with precondition to throw an error during apply if the repository is created with a service token
 resource "dbtcloud_repository" "gitlab_repo" {
   project_id         = dbtcloud_project.dbt_project.id
   remote_url         = "<gitlab-group>/<gitlab-project>"
@@ -43,6 +44,14 @@ resource "dbtcloud_repository" "gitlab_repo" {
   git_clone_strategy = "deploy_token"
 }
 
+resource "null_resource" "check_repository" {
+  lifecycle {
+    precondition {
+      condition     = dbtcloud_repository.gitlab_repo.repository_credentials_id != 0
+      error_message = "Repositories created with a service token are currently not working properly (https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/192)"
+    }
+  }
+}
 
 ### repo cloned via the deploy token strategy
 resource "dbtcloud_repository" "deploy_repo" {


### PR DESCRIPTION
While migrating our dbt resoruces to terraform i encounter the gitlab integration issue #192 where you cant create a working repository in dbt with a service token. A big problem for me is that we will use the module I'm writing to create new dbt environments/jobs/projects in the future, but the apply stage doesn't throw an error when a service token is used.

So here is a small example of how to throw an error during the apply phase when a service token is used to create a Gitlab repository.