### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.2.23...HEAD)
+## [Unreleased](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.2.24...HEAD)
+
+## [0.2.24](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.2.23...v0.2.24)
+
+## Fixes
+
+- [#247](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/247) Segfault when the env var for the token is empty
+- [Internal] Issue with `job_ids` required to be set going forward, even if it is empty
 
 ## [0.2.23](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.2.22...v0.2.23)
 

--- a/pkg/dbt_cloud/client.go
+++ b/pkg/dbt_cloud/client.go
@@ -91,6 +91,11 @@ type APIError struct {
 
 // NewClient -
 func NewClient(account_id *int, token *string, host_url *string) (*Client, error) {
+
+	if (token == nil) || (*token == "") {
+		return nil, fmt.Errorf("token is set but it is empty")
+	}
+
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 30 * time.Second},
 		HostURL:    *host_url,
@@ -98,7 +103,7 @@ func NewClient(account_id *int, token *string, host_url *string) (*Client, error
 		AccountID:  *account_id,
 	}
 
-	if (account_id != nil) && (token != nil) {
+	if account_id != nil {
 		url := fmt.Sprintf("%s/v2/accounts/", *host_url)
 
 		// authenticate

--- a/pkg/dbt_cloud/webhook.go
+++ b/pkg/dbt_cloud/webhook.go
@@ -19,7 +19,7 @@ type WebhookRead struct {
 	Description       string   `json:"description,omitempty"`
 	ClientUrl         string   `json:"client_url"`
 	EventTypes        []string `json:"event_types,omitempty"`
-	JobIds            []string `json:"job_ids,omitempty"`
+	JobIds            []string `json:"job_ids"`
 	Active            bool     `json:"active,omitempty"`
 	HmacSecret        *string  `json:"hmac_secret,omitempty"`
 	HttpStatusCode    *string  `json:"http_status_code,omitempty"`
@@ -32,12 +32,21 @@ type WebhookWrite struct {
 	Description string   `json:"description,omitempty"`
 	ClientUrl   string   `json:"client_url"`
 	EventTypes  []string `json:"event_types,omitempty"`
-	JobIds      []int    `json:"job_ids,omitempty"`
+	JobIds      []int    `json:"job_ids"`
 	Active      bool     `json:"active,omitempty"`
 }
 
 func (c *Client) GetWebhook(webhookID string) (*WebhookRead, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v3/accounts/%s/webhooks/subscription/%s", c.HostURL, strconv.Itoa(c.AccountID), webhookID), nil)
+	req, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf(
+			"%s/v3/accounts/%s/webhooks/subscription/%s",
+			c.HostURL,
+			strconv.Itoa(c.AccountID),
+			webhookID,
+		),
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +90,15 @@ func (c *Client) CreateWebhook(
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/v3/accounts/%s/webhooks/subscriptions", c.HostURL, strconv.Itoa(c.AccountID)), strings.NewReader(string(newWebhookData)))
+	req, err := http.NewRequest(
+		"POST",
+		fmt.Sprintf(
+			"%s/v3/accounts/%s/webhooks/subscriptions",
+			c.HostURL,
+			strconv.Itoa(c.AccountID),
+		),
+		strings.NewReader(string(newWebhookData)),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +123,16 @@ func (c *Client) UpdateWebhook(webhookId string, webhook WebhookWrite) (*Webhook
 		return nil, err
 	}
 
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/v3/accounts/%s/webhooks/subscription/%s", c.HostURL, strconv.Itoa(c.AccountID), webhookId), strings.NewReader(string(webhookData)))
+	req, err := http.NewRequest(
+		"PUT",
+		fmt.Sprintf(
+			"%s/v3/accounts/%s/webhooks/subscription/%s",
+			c.HostURL,
+			strconv.Itoa(c.AccountID),
+			webhookId,
+		),
+		strings.NewReader(string(webhookData)),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +152,16 @@ func (c *Client) UpdateWebhook(webhookId string, webhook WebhookWrite) (*Webhook
 }
 
 func (c *Client) DeleteWebhook(webhookId string) (string, error) {
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/v3/accounts/%s/webhooks/subscription/%s", c.HostURL, strconv.Itoa(c.AccountID), webhookId), nil)
+	req, err := http.NewRequest(
+		"DELETE",
+		fmt.Sprintf(
+			"%s/v3/accounts/%s/webhooks/subscription/%s",
+			c.HostURL,
+			strconv.Itoa(c.AccountID),
+			webhookId,
+		),
+		nil,
+	)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Fixes

- [#247](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/247) Segfault when the env var for the token is empty
- [Internal] Issue with `job_ids` required to be set going forward, even if it is empty