### PR TITLE
fix typo in docs/resources/service_token

### DIFF
--- a/docs/resources/service_token.md
+++ b/docs/resources/service_token.md
@@ -90,16 +90,16 @@ Import is supported using the following syntax:
 ```shell
 # using  import blocks (requires Terraform >= 1.5)
 import {
-  to = dbtcloud_group.my_service_token
+  to = dbtcloud_service_token.my_service_token
   id = "service_token_id"
 }
 
 import {
-  to = dbtcloud_group.my_service_token
+  to = dbtcloud_service_token.my_service_token
   id = "12345"
 }
 
 # using the older import command
-terraform import dbtcloud_group.my_service_token "service_token_id"
-terraform import dbtcloud_group.my_service_token 12345
+terraform import dbtcloud_service_token.my_service_token "service_token_id"
+terraform import dbtcloud_service_token.my_service_token 12345
 ```


### PR DESCRIPTION
I found this typo when I tried to import my service token resource.