### PR TITLE
revert removal of tests from cloud PRs

### DIFF
--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -11,12 +11,6 @@ import (
 )
 
 func TestAccDbtCloudGlobalConnectionSnowflakeResource(t *testing.T) {
-
-	if acctest_helper.IsDbtCloudPR() {
-		// TODO: remove this when global connections is on everywhere
-		t.Skip("Skipping global connections in dbt Cloud CI for now")
-	}
-
 	connectionName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	connectionName2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	oAuthClientID := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))

--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -150,12 +150,6 @@ resource dbtcloud_global_connection test {
 }
 
 func TestAccDbtCloudGlobalConnectionBigQueryResource(t *testing.T) {
-
-	if acctest_helper.IsDbtCloudPR() {
-		// TODO: remove this when global connections is on everywhere
-		t.Skip("Skipping global connections in dbt Cloud CI for now")
-	}
-
 	connectionName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	connectionName2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
@@ -317,12 +311,6 @@ resource dbtcloud_global_connection test {
 }
 
 func TestAccDbtCloudGlobalConnectionDatabricksResource(t *testing.T) {
-
-	if acctest_helper.IsDbtCloudPR() {
-		// TODO: remove this when global connections is on everywhere
-		t.Skip("Skipping global connections in dbt Cloud CI for now")
-	}
-
 	connectionName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	connectionName2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	oAuthClientID := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))

--- a/pkg/sdkv2/resources/environment_acceptance_test.go
+++ b/pkg/sdkv2/resources/environment_acceptance_test.go
@@ -207,12 +207,6 @@ resource "dbtcloud_bigquery_credential" "test_credential" {
 
 // testing for the global connection use case where connection_id is added at the env level
 func TestAccDbtCloudEnvironmentResourceConnection(t *testing.T) {
-
-	// TODO: remove this when global connection is released to all tenants
-	if os.Getenv("DBT_CLOUD_ACCOUNT_ID") == "1" {
-		t.Skip("Skipping global connections in dbt Cloud CI for now")
-	}
-
 	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	environmentName2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))

--- a/pkg/sdkv2/resources/environment_acceptance_test.go
+++ b/pkg/sdkv2/resources/environment_acceptance_test.go
@@ -2,7 +2,6 @@ package resources_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"


### PR DESCRIPTION
Global connections are on in all prs/devspaces, so this is safe to add back, assuming they pass.