### PR TITLE
attempt to fix flakiness with notifications

### DIFF
--- a/pkg/framework/objects/partial_notification/resource_acceptance_test.go
+++ b/pkg/framework/objects/partial_notification/resource_acceptance_test.go
@@ -30,6 +30,7 @@ func TestAccDbtCloudPartialNotificationResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudPartialNotificationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDbtCloudPartialNotificationResourceCreatePartialNotifications(


### PR DESCRIPTION
We've been seeing alot of flakiness with notifications related tests.  

Here's some examples:
https://github.com/dbt-labs/dbt-cloud/actions/runs/10599739892/job/29377047288?pr=12505#step:12:218
https://github.com/dbt-labs/dbt-cloud/actions/runs/10599739892/job/29380913981?pr=12505#step:12:208
https://github.com/dbt-labs/dbt-cloud/actions/runs/10599739892/job/29381607840?pr=12505#step:12:208
https://github.com/dbt-labs/dbt-cloud/actions/runs/10600515659/job/29379537697?pr=12506#step:11:217

I believe it might all stem from this, potentially.  Somewhat blindly attempting this. 

Ran the tests 3 times to try and better ensure this works and doesn't cause any unforeseen problems, and all 3 succeeded. 