### PR TITLE
[CC-1769] - Make dbname for postgres, redshift a required field due to api updates

### DIFF
--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -554,6 +554,7 @@ resource dbtcloud_global_connection test {
   redshift = {
     hostname = "test.com"
 	port = 9876
+	dbname = "my_database"
   }
 }
 
@@ -570,9 +571,9 @@ resource dbtcloud_global_connection test {
   redshift = {
     hostname = "test.com"
 	port = 1234
+	dbname = "my_database"
 
 	// optional fields
-	dbname = "my_database"
     ssh_tunnel = {
       username = "user"
       hostname = "host2"
@@ -694,6 +695,7 @@ resource dbtcloud_global_connection test {
   postgres = {
     hostname = "test.com"
 	port = 9876
+	dbname = "my_database"
   }
 }
 
@@ -710,9 +712,9 @@ resource dbtcloud_global_connection test {
   postgres = {
     hostname = "test.com"
 	port = 1234
+	dbname = "my_database"
 
 	// optional fields
-	dbname = "my_database"
     ssh_tunnel = {
       username = "user"
       hostname = "host2"


### PR DESCRIPTION
`dbname` is a required field that we do validation on in response but not on the request. We should have the same validation rules both ways. Changing this broke the following terraform test:
```
"developer_message":"Invalid request data: 1 validation error for
        PostAccountConnection\n__root__ -> dbname\n  none is not an allowed value
```

So updating this to pass in a db name for the terraform test.