### PR TITLE
Make dbname mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v1.3.15...HEAD)
+## [Unreleased](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.16...HEAD)
+
+# [0.3.16](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.15...v0.3.16)
+
+### Changes
+
+- Make `dbname` required for Redshift and Postgres in `dbtcloud_global_connection`
+
 
 # [0.3.15](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.14...v0.3.15)
 

--- a/docs/data-sources/projects.md
+++ b/docs/data-sources/projects.md
@@ -20,7 +20,6 @@ data dbtcloud_projects my_acme_projects {
 
 // or can return all projects
 data dbtcloud_projects my_projects {
-  name_contains = "acme"
 }
 
 // this can be used to make sure that there are no distinct projects with the same names for example

--- a/docs/resources/global_connection.md
+++ b/docs/resources/global_connection.md
@@ -282,11 +282,11 @@ Optional:
 
 Required:
 
+- `dbname` (String) The database name for this connection.
 - `hostname` (String) The hostname of the database.
 
 Optional:
 
-- `dbname` (String) The database name for this connection.
 - `port` (Number) The port to connect to for this connection. Default=5432
 - `ssh_tunnel` (Attributes) PostgreSQL SSH Tunnel configuration (see [below for nested schema](#nestedatt--postgres--ssh_tunnel))
 
@@ -311,11 +311,11 @@ Read-Only:
 
 Required:
 
+- `dbname` (String) The database name for this connection.
 - `hostname` (String) The hostname of the data warehouse.
 
 Optional:
 
-- `dbname` (String) The database name for this connection.
 - `port` (Number) The port to connect to for this connection. Default=5432
 - `ssh_tunnel` (Attributes) Redshift SSH Tunnel configuration (see [below for nested schema](#nestedatt--redshift--ssh_tunnel))
 

--- a/examples/data-sources/dbtcloud_projects/data-source.tf
+++ b/examples/data-sources/dbtcloud_projects/data-source.tf
@@ -6,7 +6,6 @@ data dbtcloud_projects my_acme_projects {
 
 // or can return all projects
 data dbtcloud_projects my_projects {
-  name_contains = "acme"
 }
 
 // this can be used to make sure that there are no distinct projects with the same names for example

--- a/pkg/dbt_cloud/client.go
+++ b/pkg/dbt_cloud/client.go
@@ -135,7 +135,7 @@ func NewClient(account_id *int, token *string, host_url *string) (*Client, error
 		}
 
 		return nil, fmt.Errorf(
-			"the token is valid but does not have access to the account id %d",
+			"the token is valid but does not have access to the account id %d. This might be due to a lack of permissions or because IP restrictions are in place for the account",
 			*account_id,
 		)
 

--- a/pkg/framework/objects/global_connection/schema.go
+++ b/pkg/framework/objects/global_connection/schema.go
@@ -273,7 +273,7 @@ func (r *globalConnectionResource) Schema(
 						Description: "The port to connect to for this connection. Default=5432",
 					},
 					"dbname": resource_schema.StringAttribute{
-						Optional:    true,
+						Required:    true,
 						Description: "The database name for this connection.",
 					},
 					// for SSH tunnel details
@@ -320,7 +320,7 @@ func (r *globalConnectionResource) Schema(
 						Description: "The port to connect to for this connection. Default=5432",
 					},
 					"dbname": resource_schema.StringAttribute{
-						Optional:    true,
+						Required:    true,
 						Description: "The database name for this connection.",
 					},
 					// for SSH tunnel details


### PR DESCRIPTION
### Changes

- Make `dbname` required for Redshift and Postgres in `dbtcloud_global_connection`