### PR TITLE
Add better error handling when splitting IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.17...HEAD)
+## [Unreleased](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.18...HEAD)
+
+# [0.3.18](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.17...v0.3.18)
+
+### Behind the scenes
+
+- Add better error handling when importing resources like in [#299](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/299)
 
 # [0.3.17](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.16...v0.3.17)
 

--- a/pkg/helper/split_id.go
+++ b/pkg/helper/split_id.go
@@ -1,0 +1,51 @@
+package helper
+
+import (
+	"fmt"
+	"strconv"
+	strings "strings"
+
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+)
+
+func SplitIDToStrings(id string, resource_type string) (string, string, error) {
+	parts := strings.Split(id, dbt_cloud.ID_DELIMITER)
+	if len(parts) != 2 {
+
+		err := fmt.Errorf(
+			"expected ID in the format 'id1%sid2' to import a %s, got: %s",
+			dbt_cloud.ID_DELIMITER,
+			resource_type,
+			id,
+		)
+		return "", "", err
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func SplitIDToInts(id string, resource_type string) (int, int, error) {
+	parts := strings.Split(id, dbt_cloud.ID_DELIMITER)
+	if len(parts) != 2 {
+
+		err := fmt.Errorf(
+			"expected ID in the format 'id1%sid2' to import a %s, got: %s",
+			dbt_cloud.ID_DELIMITER,
+			resource_type,
+			id,
+		)
+		return 0, 0, err
+	}
+
+	id1, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("error converting %s to int when splitting the ID", parts[0])
+	}
+
+	id2, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("error converting %s to int when splitting the ID", parts[1])
+	}
+
+	return id1, id2, nil
+}

--- a/pkg/sdkv2/resources/bigquery_connection.go
+++ b/pkg/sdkv2/resources/bigquery_connection.go
@@ -312,8 +312,13 @@ func resourceBigQueryConnectionRead(
 
 	var diags diag.Diagnostics
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	connectionIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, connectionIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_bigquery_connection",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	connection, err := c.GetBigQueryConnection(connectionIdString, projectIdString)
 	if err != nil {
@@ -407,8 +412,13 @@ func resourceBigQueryConnectionUpdate(
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	connectionIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, connectionIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"bigquery_connection",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if d.HasChange("name") ||
 		d.HasChange("type") ||

--- a/pkg/sdkv2/resources/bigquery_connection_acceptance_test.go
+++ b/pkg/sdkv2/resources/bigquery_connection_acceptance_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -253,8 +253,10 @@ func testAccCheckDbtCloudBigQueryConnectionDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_bigquery_connection" {
 			continue
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
-		connectionId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1]
+		projectId, connectionId, _ := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_bigquery_connection",
+		)
 
 		_, err := apiClient.GetConnection(connectionId, projectId)
 		if err == nil {

--- a/pkg/sdkv2/resources/bigquery_credential.go
+++ b/pkg/sdkv2/resources/bigquery_credential.go
@@ -3,10 +3,10 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -104,12 +104,10 @@ func resourceBigQueryCredentialRead(
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	BigQueryCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, BigQueryCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_bigquery_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -149,12 +147,10 @@ func resourceBigQueryCredentialUpdate(
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	BigQueryCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, BigQueryCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_bigquery_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -192,10 +188,15 @@ func resourceBigQueryCredentialDelete(
 
 	var diags diag.Diagnostics
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	BigQueryCredentialIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, BigQueryCredentialIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_bigquery_credential",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	_, err := c.DeleteCredential(BigQueryCredentialIdString, projectIdString)
+	_, err = c.DeleteCredential(BigQueryCredentialIdString, projectIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/sdkv2/resources/bigquery_credential_acceptance_test.go
+++ b/pkg/sdkv2/resources/bigquery_credential_acceptance_test.go
@@ -3,12 +3,11 @@ package resources_test
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -73,13 +72,13 @@ func testAccCheckDbtCloudBigQueryCredentialExists(resource string) resource.Test
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No Record ID is set")
 		}
-		projectId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0])
+
+		projectId, credentialId, err := helper.SplitIDToInts(
+			rs.Primary.ID,
+			"dbtcloud_bigquery_credential",
+		)
 		if err != nil {
-			return fmt.Errorf("Can't get projectId")
-		}
-		credentialId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1])
-		if err != nil {
-			return fmt.Errorf("Can't get credentialId")
+			return err
 		}
 
 		apiClient, err := acctest_helper.SharedClient()
@@ -104,13 +103,12 @@ func testAccCheckDbtCloudBigQueryCredentialDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_bigquery_credential" {
 			continue
 		}
-		projectId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0])
+		projectId, credentialId, err := helper.SplitIDToInts(
+			rs.Primary.ID,
+			"dbtcloud_bigquery_credential",
+		)
 		if err != nil {
-			return fmt.Errorf("Can't get projectId")
-		}
-		credentialId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1])
-		if err != nil {
-			return fmt.Errorf("Can't get credentialId")
+			return err
 		}
 
 		_, err = apiClient.GetBigQueryCredential(projectId, credentialId)

--- a/pkg/sdkv2/resources/connection.go
+++ b/pkg/sdkv2/resources/connection.go
@@ -228,8 +228,13 @@ func resourceConnectionRead(
 
 	var diags diag.Diagnostics
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	connectionIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, connectionIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_connection",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	connection, err := c.GetConnection(connectionIdString, projectIdString)
 	if err != nil {
@@ -240,7 +245,6 @@ func resourceConnectionRead(
 		return diag.FromErr(err)
 	}
 
-	// TODO: Remove when done better
 	connection.Details.OAuthClientID = d.Get("oauth_client_id").(string)
 	connection.Details.OAuthClientSecret = d.Get("oauth_client_secret").(string)
 
@@ -347,8 +351,13 @@ func resourceConnectionUpdate(
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	connectionIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, connectionIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_connection",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if d.HasChange("name") ||
 		d.HasChange("type") ||
@@ -467,10 +476,15 @@ func resourceConnectionDelete(
 
 	var diags diag.Diagnostics
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	connectionIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, connectionIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_connection",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	_, err := c.DeleteConnection(connectionIdString, projectIdString)
+	_, err = c.DeleteConnection(connectionIdString, projectIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/sdkv2/resources/connection_acceptance_test.go
+++ b/pkg/sdkv2/resources/connection_acceptance_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -587,8 +587,13 @@ func testAccCheckDbtCloudConnectionExists(resource string) resource.TestCheckFun
 		if err != nil {
 			return fmt.Errorf("Issue getting the client")
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
-		connectionId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1]
+		projectId, connectionId, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_connection",
+		)
+		if err != nil {
+			return err
+		}
 
 		_, err = apiClient.GetConnection(connectionId, projectId)
 		if err != nil {
@@ -608,10 +613,15 @@ func testAccCheckDbtCloudConnectionDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_connection" {
 			continue
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
-		connectionId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1]
+		projectId, connectionId, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_connection",
+		)
+		if err != nil {
+			return err
+		}
 
-		_, err := apiClient.GetConnection(connectionId, projectId)
+		_, err = apiClient.GetConnection(connectionId, projectId)
 		if err == nil {
 			return fmt.Errorf("Connection still exists")
 		}

--- a/pkg/sdkv2/resources/databricks_credential.go
+++ b/pkg/sdkv2/resources/databricks_credential.go
@@ -3,10 +3,10 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -135,13 +135,10 @@ func resourceDatabricksCredentialRead(
 
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
-
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	databricksCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, databricksCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_databricks_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -189,13 +186,10 @@ func resourceDatabricksCredentialUpdate(
 	m interface{},
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
-
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	databricksCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, databricksCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_databricks_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -317,11 +311,10 @@ func resourceDatabricksCredentialDelete(
 
 	var diags diag.Diagnostics
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	databricksCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, databricksCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_databricks_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/sdkv2/resources/databricks_credential_acceptance_test.go
+++ b/pkg/sdkv2/resources/databricks_credential_acceptance_test.go
@@ -3,12 +3,11 @@ package resources_test
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -91,13 +90,12 @@ func testAccCheckDbtCloudDatabricksCredentialExists(resource string) resource.Te
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No Record ID is set")
 		}
-		projectId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0])
+		projectId, credentialId, err := helper.SplitIDToInts(
+			rs.Primary.ID,
+			"dbtcloud_databricks_credential",
+		)
 		if err != nil {
-			return fmt.Errorf("Can't get projectId")
-		}
-		credentialId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1])
-		if err != nil {
-			return fmt.Errorf("Can't get projectId")
+			return err
 		}
 
 		apiClient, err := acctest_helper.SharedClient()
@@ -122,13 +120,12 @@ func testAccCheckDbtCloudDatabricksCredentialDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_databricks_credential" {
 			continue
 		}
-		projectId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0])
+		projectId, credentialId, err := helper.SplitIDToInts(
+			rs.Primary.ID,
+			"dbtcloud_databricks_credential",
+		)
 		if err != nil {
-			return fmt.Errorf("Can't get projectId")
-		}
-		credentialId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1])
-		if err != nil {
-			return fmt.Errorf("Can't get credentialId")
+			return err
 		}
 
 		_, err = apiClient.GetDatabricksCredential(projectId, credentialId)

--- a/pkg/sdkv2/resources/environment.go
+++ b/pkg/sdkv2/resources/environment.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
@@ -180,12 +179,7 @@ func resourceEnvironmentRead(
 
 	var diags diag.Diagnostics
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	environmentId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, environmentId, err := helper.SplitIDToInts(d.Id(), "dbtcloud_environment")
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -252,12 +246,10 @@ func resourceEnvironmentUpdate(
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	environmentId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, environmentId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_environment",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -348,12 +340,10 @@ func resourceEnvironmentDelete(
 
 	var diags diag.Diagnostics
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	environmentId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, environmentId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_environment",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/sdkv2/resources/extended_attributes.go
+++ b/pkg/sdkv2/resources/extended_attributes.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -104,13 +104,10 @@ func resourceExtendedAttributesRead(
 	c := m.(*dbt_cloud.Client)
 
 	var diags diag.Diagnostics
-
-	projectID, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	extendedAttributesID, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectID, extendedAttributesID, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_extended_attributes",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -164,12 +161,10 @@ func resourceExtendedAttributesUpdate(
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	extendedAttributesId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, extendedAttributesId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_extended_attributes",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -216,12 +211,10 @@ func resourceExtendedAttributesDelete(
 
 	var diags diag.Diagnostics
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	extendedAttributesId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, extendedAttributesId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_extended_attributes",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/sdkv2/resources/fabric_connection.go
+++ b/pkg/sdkv2/resources/fabric_connection.go
@@ -137,8 +137,13 @@ func resourceFabricConnectionRead(
 
 	var diags diag.Diagnostics
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	connectionIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, connectionIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_fabric_connection",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	connection, err := c.GetFabricConnection(connectionIdString, projectIdString)
 	if err != nil {
@@ -190,8 +195,13 @@ func resourceFabricConnectionUpdate(
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	connectionIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, connectionIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_fabric_connection",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if d.HasChange("name") ||
 		d.HasChange("state") ||

--- a/pkg/sdkv2/resources/fabric_connection_acceptance_test.go
+++ b/pkg/sdkv2/resources/fabric_connection_acceptance_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -177,10 +177,15 @@ func testAccCheckDbtCloudFabricConnectionDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_fabric_connection" {
 			continue
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
-		connectionId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1]
+		projectId, connectionId, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_fabric_connection",
+		)
+		if err != nil {
+			return err
+		}
 
-		_, err := apiClient.GetConnection(connectionId, projectId)
+		_, err = apiClient.GetConnection(connectionId, projectId)
 		if err == nil {
 			return fmt.Errorf("Connection still exists")
 		}

--- a/pkg/sdkv2/resources/fabric_credential.go
+++ b/pkg/sdkv2/resources/fabric_credential.go
@@ -3,10 +3,10 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -160,12 +160,10 @@ func resourceFabricCredentialRead(
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	fabricCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, fabricCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_fabric_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -224,12 +222,10 @@ func resourceFabricCredentialUpdate(
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	fabricCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, fabricCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_fabric_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -306,11 +302,10 @@ func resourceFabricCredentialDelete(
 
 	var diags diag.Diagnostics
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	fabricCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, fabricCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_fabric_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/sdkv2/resources/fabric_credential_acceptance_test.go
+++ b/pkg/sdkv2/resources/fabric_credential_acceptance_test.go
@@ -3,12 +3,11 @@ package resources_test
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -151,13 +150,12 @@ func testAccCheckDbtCloudFabricCredentialExists(resource string) resource.TestCh
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No Record ID is set")
 		}
-		projectId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0])
+		projectId, credentialId, err := helper.SplitIDToInts(
+			rs.Primary.ID,
+			"dbtcloud_fabric_credential",
+		)
 		if err != nil {
-			return fmt.Errorf("Can't get projectId")
-		}
-		credentialId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1])
-		if err != nil {
-			return fmt.Errorf("Can't get projectId")
+			return err
 		}
 
 		apiClient, err := acctest_helper.SharedClient()
@@ -182,13 +180,12 @@ func testAccCheckDbtCloudFabricCredentialDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_fabric_credential" {
 			continue
 		}
-		projectId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0])
+		projectId, credentialId, err := helper.SplitIDToInts(
+			rs.Primary.ID,
+			"dbtcloud_fabric_credential",
+		)
 		if err != nil {
-			return fmt.Errorf("Can't get projectId")
-		}
-		credentialId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1])
-		if err != nil {
-			return fmt.Errorf("Can't get credentialId")
+			return err
 		}
 
 		_, err = apiClient.GetFabricCredential(projectId, credentialId)

--- a/pkg/sdkv2/resources/postgres_credential.go
+++ b/pkg/sdkv2/resources/postgres_credential.go
@@ -3,10 +3,10 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -142,12 +142,10 @@ func resourcePostgresCredentialRead(
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	postgresCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, postgresCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_postgres_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -201,12 +199,10 @@ func resourcePostgresCredentialUpdate(
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	postgresCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, postgresCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_postgres_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -262,10 +258,15 @@ func resourcePostgresCredentialDelete(
 
 	var diags diag.Diagnostics
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	postgresCredentialIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, postgresCredentialIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_postgres_credential",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	_, err := c.DeleteCredential(postgresCredentialIdString, projectIdString)
+	_, err = c.DeleteCredential(postgresCredentialIdString, projectIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/sdkv2/resources/postgres_credential_acceptance_test.go
+++ b/pkg/sdkv2/resources/postgres_credential_acceptance_test.go
@@ -3,12 +3,11 @@ package resources_test
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -100,13 +99,12 @@ func testAccCheckDbtCloudPostgresCredentialExists(resource string) resource.Test
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No Record ID is set")
 		}
-		projectId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0])
+		projectId, credentialId, err := helper.SplitIDToInts(
+			rs.Primary.ID,
+			"dbtcloud_postgres_credential",
+		)
 		if err != nil {
-			return fmt.Errorf("Can't get projectId")
-		}
-		credentialId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1])
-		if err != nil {
-			return fmt.Errorf("Can't get credentialId")
+			return err
 		}
 
 		apiClient, err := acctest_helper.SharedClient()
@@ -131,13 +129,12 @@ func testAccCheckDbtCloudPostgresCredentialDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_postgres_credential" {
 			continue
 		}
-		projectId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0])
+		projectId, credentialId, err := helper.SplitIDToInts(
+			rs.Primary.ID,
+			"dbtcloud_postgres_credential",
+		)
 		if err != nil {
-			return fmt.Errorf("Can't get projectId")
-		}
-		credentialId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1])
-		if err != nil {
-			return fmt.Errorf("Can't get credentialId")
+			return err
 		}
 
 		_, err = apiClient.GetPostgresCredential(projectId, credentialId)

--- a/pkg/sdkv2/resources/project_artefacts_acceptance_test.go
+++ b/pkg/sdkv2/resources/project_artefacts_acceptance_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -120,7 +120,13 @@ func testAccCheckDbtCloudProjectArtefactsExists(resource string) resource.TestCh
 		if err != nil {
 			return fmt.Errorf("Issue getting the client")
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
+		projectId, _, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_project_artefacts",
+		)
+		if err != nil {
+			return err
+		}
 		project, err := apiClient.GetProject(projectId)
 		if err != nil {
 			return fmt.Errorf("Can't get project")
@@ -172,7 +178,13 @@ func testAccCheckDbtCloudProjectArtefactsDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_project_artefacts" {
 			continue
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
+		projectId, _, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_project_artefacts",
+		)
+		if err != nil {
+			return err
+		}
 		project, err := apiClient.GetProject(projectId)
 		if project != nil {
 			return fmt.Errorf("Project still exists")

--- a/pkg/sdkv2/resources/project_artefacts_acceptance_test.go
+++ b/pkg/sdkv2/resources/project_artefacts_acceptance_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -120,13 +119,7 @@ func testAccCheckDbtCloudProjectArtefactsExists(resource string) resource.TestCh
 		if err != nil {
 			return fmt.Errorf("Issue getting the client")
 		}
-		projectId, _, err := helper.SplitIDToStrings(
-			rs.Primary.ID,
-			"dbtcloud_project_artefacts",
-		)
-		if err != nil {
-			return err
-		}
+		projectId := rs.Primary.ID
 		project, err := apiClient.GetProject(projectId)
 		if err != nil {
 			return fmt.Errorf("Can't get project")
@@ -178,13 +171,7 @@ func testAccCheckDbtCloudProjectArtefactsDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_project_artefacts" {
 			continue
 		}
-		projectId, _, err := helper.SplitIDToStrings(
-			rs.Primary.ID,
-			"dbtcloud_project_artefacts",
-		)
-		if err != nil {
-			return err
-		}
+		projectId := rs.Primary.ID
 		project, err := apiClient.GetProject(projectId)
 		if project != nil {
 			return fmt.Errorf("Project still exists")

--- a/pkg/sdkv2/resources/project_connection_acceptance_test.go
+++ b/pkg/sdkv2/resources/project_connection_acceptance_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -85,7 +86,13 @@ func testAccCheckDbtCloudProjectConnectionExists(resource string) resource.TestC
 		if err != nil {
 			return fmt.Errorf("Issue getting the client")
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
+		projectId, _, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_project_connection",
+		)
+		if err != nil {
+			return err
+		}
 		project, err := apiClient.GetProject(projectId)
 		if err != nil {
 			return fmt.Errorf("Can't get project")
@@ -107,7 +114,12 @@ func testAccCheckDbtCloudProjectConnectionDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_project_connection" {
 			continue
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
+		projectId, _, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_project_connection",
+		)
+		if err != nil {
+		
 		project, err := apiClient.GetProject(projectId)
 		if project != nil {
 			return fmt.Errorf("Project still exists")

--- a/pkg/sdkv2/resources/project_connection_acceptance_test.go
+++ b/pkg/sdkv2/resources/project_connection_acceptance_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -119,7 +118,9 @@ func testAccCheckDbtCloudProjectConnectionDestroy(s *terraform.State) error {
 			"dbtcloud_project_connection",
 		)
 		if err != nil {
-		
+			return err
+		}
+
 		project, err := apiClient.GetProject(projectId)
 		if project != nil {
 			return fmt.Errorf("Project still exists")

--- a/pkg/sdkv2/resources/project_repository.go
+++ b/pkg/sdkv2/resources/project_repository.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -80,12 +81,13 @@ func resourceProjectRepositoryRead(
 	c := m.(*dbt_cloud.Client)
 
 	var diags diag.Diagnostics
-
-	projectID, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
+	projectIDString, _, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_project_repository",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	projectIDString := strconv.Itoa(projectID)
 
 	project, err := c.GetProject(projectIDString)
 	if err != nil {

--- a/pkg/sdkv2/resources/project_repository_acceptance_test.go
+++ b/pkg/sdkv2/resources/project_repository_acceptance_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -101,7 +101,13 @@ func testAccCheckDbtCloudProjectRepositoryExists(resource string) resource.TestC
 		if err != nil {
 			return fmt.Errorf("Issue getting the client")
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
+		projectId, _, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_project_repository",
+		)
+		if err != nil {
+			return err
+		}
 		project, err := apiClient.GetProject(projectId)
 		if err != nil {
 			return fmt.Errorf("Can't get project")
@@ -147,7 +153,13 @@ func testAccCheckDbtCloudProjectRepositoryDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_project_repository" {
 			continue
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
+		projectId, _, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_project_repository",
+		)
+		if err != nil {
+			return err
+		}
 		project, err := apiClient.GetProject(projectId)
 		if project != nil {
 			return fmt.Errorf("Project still exists")

--- a/pkg/sdkv2/resources/repository.go
+++ b/pkg/sdkv2/resources/repository.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -180,9 +181,13 @@ func resourceRepositoryRead(
 	c := m.(*dbt_cloud.Client)
 
 	var diags diag.Diagnostics
-
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	repositoryIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, repositoryIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_repository",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	repository, err := c.GetRepository(repositoryIdString, projectIdString)
 	if err != nil {
@@ -247,8 +252,13 @@ func resourceRepositoryUpdate(
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	repositoryIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, repositoryIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_repository",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if d.HasChange("is_active") || d.HasChange("pull_request_url_template") {
 		repository, err := c.GetRepository(repositoryIdString, projectIdString)
@@ -286,10 +296,15 @@ func resourceRepositoryDelete(
 
 	var diags diag.Diagnostics
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	repositoryIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, repositoryIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_repository",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	_, err := c.DeleteRepository(repositoryIdString, projectIdString)
+	_, err = c.DeleteRepository(repositoryIdString, projectIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/sdkv2/resources/repository_acceptance_test.go
+++ b/pkg/sdkv2/resources/repository_acceptance_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -159,9 +159,13 @@ func testAccCheckDbtCloudRepositoryExists(resource string) resource.TestCheckFun
 		if err != nil {
 			return fmt.Errorf("Issue getting the client")
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
-		repositoryId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1]
-
+		projectId, repositoryId, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_repository",
+		)
+		if err != nil {
+			return err
+		}
 		_, err = apiClient.GetRepository(repositoryId, projectId)
 		if err != nil {
 			return fmt.Errorf("error fetching item with resource %s. %s", resource, err)
@@ -180,10 +184,14 @@ func testAccCheckDbtCloudRepositoryDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_repository" {
 			continue
 		}
-		projectId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0]
-		repositoryId := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1]
-
-		_, err := apiClient.GetRepository(repositoryId, projectId)
+		projectId, repositoryId, err := helper.SplitIDToStrings(
+			rs.Primary.ID,
+			"dbtcloud_repository",
+		)
+		if err != nil {
+			return err
+		}
+		_, err = apiClient.GetRepository(repositoryId, projectId)
 		if err == nil {
 			return fmt.Errorf("Repository still exists")
 		}

--- a/pkg/sdkv2/resources/snowflake_credential.go
+++ b/pkg/sdkv2/resources/snowflake_credential.go
@@ -3,10 +3,10 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -174,13 +174,10 @@ func resourceSnowflakeCredentialRead(
 
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
-
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	snowflakeCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, snowflakeCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_snowflake_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -252,12 +249,10 @@ func resourceSnowflakeCredentialUpdate(
 ) diag.Diagnostics {
 	c := m.(*dbt_cloud.Client)
 
-	projectId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0])
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	snowflakeCredentialId, err := strconv.Atoi(strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1])
+	projectId, snowflakeCredentialId, err := helper.SplitIDToInts(
+		d.Id(),
+		"dbtcloud_snowflake_credential",
+	)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -334,10 +329,15 @@ func resourceSnowflakeCredentialDelete(
 
 	var diags diag.Diagnostics
 
-	projectIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[0]
-	snowflakeCredentialIdString := strings.Split(d.Id(), dbt_cloud.ID_DELIMITER)[1]
+	projectIdString, snowflakeCredentialIdString, err := helper.SplitIDToStrings(
+		d.Id(),
+		"dbtcloud_snowflake_credential",
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	_, err := c.DeleteCredential(snowflakeCredentialIdString, projectIdString)
+	_, err = c.DeleteCredential(snowflakeCredentialIdString, projectIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/sdkv2/resources/snowflake_credential_acceptance_test.go
+++ b/pkg/sdkv2/resources/snowflake_credential_acceptance_test.go
@@ -3,12 +3,11 @@ package resources_test
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -262,13 +261,13 @@ func testAccCheckDbtCloudSnowflakeCredentialExists(resource string) resource.Tes
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No Record ID is set")
 		}
-		projectId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0])
+
+		projectId, credentialId, err := helper.SplitIDToInts(
+			rs.Primary.ID,
+			"dbtcloud_snowflake_credential",
+		)
 		if err != nil {
-			return fmt.Errorf("Can't get projectId")
-		}
-		credentialId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1])
-		if err != nil {
-			return fmt.Errorf("Can't get projectId")
+			return err
 		}
 
 		apiClient, err := acctest_helper.SharedClient()
@@ -293,13 +292,12 @@ func testAccCheckDbtCloudSnowflakeCredentialDestroy(s *terraform.State) error {
 		if rs.Type != "dbtcloud_snowflake_credential" {
 			continue
 		}
-		projectId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[0])
+		projectId, credentialId, err := helper.SplitIDToInts(
+			rs.Primary.ID,
+			"dbtcloud_snowflake_credential",
+		)
 		if err != nil {
-			return fmt.Errorf("Can't get projectId")
-		}
-		credentialId, err := strconv.Atoi(strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)[1])
-		if err != nil {
-			return fmt.Errorf("Can't get projectId")
+			return err
 		}
 
 		_, err = apiClient.GetSnowflakeCredential(projectId, credentialId)


### PR DESCRIPTION
Add better error handling instead of panicking when IDs can't be split properly.

Related to #299