### PR TITLE
fix: Set default dbt_version to latest and add diff logic to treat versionless and latest as equivalents

### DIFF
--- a/docs/guides/1_getting_started.md
+++ b/docs/guides/1_getting_started.md
@@ -99,7 +99,7 @@ resource "dbtcloud_project_repository" "my_project_repository" {
 // here both are linked to the same Data Warehouse connection
 // for Prod, we need to create a credential as well
 resource "dbtcloud_environment" "my_dev" {
-  dbt_version     = "versionless"
+  dbt_version     = "latest"
   name            = "Dev"
   project_id      = dbtcloud_project.my_project.id
   type            = "development"
@@ -107,7 +107,7 @@ resource "dbtcloud_environment" "my_dev" {
 }
 
 resource "dbtcloud_environment" "my_prod" {
-  dbt_version     = "versionless"
+  dbt_version     = "latest"
   name            = "Prod"
   project_id      = dbtcloud_project.my_project.id
   type            = "deployment"

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -22,8 +22,8 @@ This version of the provider has the `connection_id` as an optional field but it
 
 ```terraform
 resource "dbtcloud_environment" "ci_environment" {
-  // the dbt_version is major.minor.0-latest , major.minor.0-pre or versionless (by default, it is set to versionless if not configured)
-  dbt_version   = "versionless"
+  // the dbt_version is major.minor.0-latest , major.minor.0-pre or latest (by default, it is set to latest if not configured)
+  dbt_version   = "latest"
   name          = "CI"
   project_id    = dbtcloud_project.dbt_project.id
   type          = "deployment"
@@ -44,7 +44,7 @@ resource "dbtcloud_environment" "prod_environment" {
 
 // Creating a development environment
 resource "dbtcloud_environment" "dev_environment" {
-  dbt_version = "versionless"
+  dbt_version = "latest"
   name        = "Dev"
   project_id  = dbtcloud_project.dbt_project.id
   type        = "development"

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -70,7 +70,7 @@ resource "dbtcloud_environment" "dev_environment" {
   - To avoid Terraform state issues, when using this field, the `dbtcloud_project_connection` resource should be removed from the project or you need to make sure that the `connection_id` is the same in `dbtcloud_project_connection` and in the `connection_id` of the Development environment of the project
 - `credential_id` (Number) Credential ID to create the environment with. A credential is not required for development environments but is required for deployment environments
 - `custom_branch` (String) Which custom branch to use in this environment
-- `dbt_version` (String) Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `versionless`, or `latest`. While `versionless` is still supported, using `latest` is recommended. Defaults to`latest` if no version is provided
+- `dbt_version` (String) Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `versionless`, or `latest`. While `versionless` is still supported, using `latest` is recommended. Defaults to `latest` if no version is provided
 - `deployment_type` (String) The type of environment. Only valid for environments of type 'deployment' and for now can only be 'production', 'staging' or left empty for generic environments
 - `enable_model_query_history` (Boolean) Whether to enable model query history in this environment. As of Oct 2024, works only for Snowflake and BigQuery.
 - `extended_attributes_id` (Number) ID of the extended attributes for the environment

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -70,7 +70,7 @@ resource "dbtcloud_environment" "dev_environment" {
   - To avoid Terraform state issues, when using this field, the `dbtcloud_project_connection` resource should be removed from the project or you need to make sure that the `connection_id` is the same in `dbtcloud_project_connection` and in the `connection_id` of the Development environment of the project
 - `credential_id` (Number) Credential ID to create the environment with. A credential is not required for development environments but is required for deployment environments
 - `custom_branch` (String) Which custom branch to use in this environment
-- `dbt_version` (String) Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre` or `versionless`. Defaults to`versionless` if no version is provided
+- `dbt_version` (String) Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `versionless`, or `latest`. While `versionless` is still supported, using `latest` is recommended. Defaults to`latest` if no version is provided
 - `deployment_type` (String) The type of environment. Only valid for environments of type 'deployment' and for now can only be 'production', 'staging' or left empty for generic environments
 - `enable_model_query_history` (Boolean) Whether to enable model query history in this environment. As of Oct 2024, works only for Snowflake and BigQuery.
 - `extended_attributes_id` (Number) ID of the extended attributes for the environment

--- a/docs/resources/extended_attributes.md
+++ b/docs/resources/extended_attributes.md
@@ -30,7 +30,7 @@ resource "dbtcloud_extended_attributes" "my_attributes" {
 }
 
 resource "dbtcloud_environment" "issue_depl" {
-  dbt_version            = "versionless"
+  dbt_version            = "latest"
   name                   = "My environment"
   project_id             = var.dbt_project.id
   type                   = "deployment"

--- a/examples/resources/dbtcloud_environment/resource.tf
+++ b/examples/resources/dbtcloud_environment/resource.tf
@@ -1,6 +1,6 @@
 resource "dbtcloud_environment" "ci_environment" {
-  // the dbt_version is major.minor.0-latest , major.minor.0-pre or versionless (by default, it is set to versionless if not configured)
-  dbt_version   = "versionless"
+  // the dbt_version is major.minor.0-latest , major.minor.0-pre or latest (by default, it is set to latest if not configured)
+  dbt_version   = "latest"
   name          = "CI"
   project_id    = dbtcloud_project.dbt_project.id
   type          = "deployment"
@@ -21,7 +21,7 @@ resource "dbtcloud_environment" "prod_environment" {
 
 // Creating a development environment
 resource "dbtcloud_environment" "dev_environment" {
-  dbt_version = "versionless"
+  dbt_version = "latest"
   name        = "Dev"
   project_id  = dbtcloud_project.dbt_project.id
   type        = "development"

--- a/examples/resources/dbtcloud_extended_attributes/resource.tf
+++ b/examples/resources/dbtcloud_extended_attributes/resource.tf
@@ -15,7 +15,7 @@ resource "dbtcloud_extended_attributes" "my_attributes" {
 }
 
 resource "dbtcloud_environment" "issue_depl" {
-  dbt_version            = "versionless"
+  dbt_version            = "latest"
   name                   = "My environment"
   project_id             = var.dbt_project.id
   type                   = "deployment"

--- a/pkg/framework/acctest_helper/acctest_helper.go
+++ b/pkg/framework/acctest_helper/acctest_helper.go
@@ -41,7 +41,7 @@ func SharedClient() (*dbt_cloud.Client, error) {
 }
 
 const (
-	DBT_CLOUD_VERSION = "versionless"
+	DBT_CLOUD_VERSION = "latest"
 )
 
 var TestAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/pkg/sdkv2/data_sources/helpers_test.go
+++ b/pkg/sdkv2/data_sources/helpers_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	DBT_CLOUD_VERSION = "versionless"
+	DBT_CLOUD_VERSION = "latest"
 )
 
 func providers() map[string]*schema.Provider {

--- a/pkg/sdkv2/resources/environment.go
+++ b/pkg/sdkv2/resources/environment.go
@@ -51,10 +51,22 @@ func ResourceEnvironment() *schema.Resource {
 				Description: "Environment name",
 			},
 			"dbt_version": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "versionless",
-				Description: "Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre` or `versionless`. Defaults to`versionless` if no version is provided",
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "latest",
+				Description: "Version number of dbt to use in this environment. " +
+					"It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), " +
+					"`major.minor.0-pre`, `versionless`, or `latest`. While `versionless` is still supported, " +
+					"using `latest` is recommended. Defaults to`latest` if no version is provided",
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					if (oldValue == "latest" || oldValue == "versionless") &&
+						(newValue == "latest" || newValue == "versionless") {
+						return true
+					}
+
+					return oldValue == newValue
+
+				},
 			},
 			"type": {
 				Type:        schema.TypeString,

--- a/pkg/sdkv2/resources/environment.go
+++ b/pkg/sdkv2/resources/environment.go
@@ -60,9 +60,7 @@ func ResourceEnvironment() *schema.Resource {
 						(newValue == "latest" || newValue == "versionless") {
 						return true
 					}
-
-					return oldValue == newValue
-
+					return false
 				},
 			},
 			"type": {

--- a/pkg/sdkv2/resources/environment.go
+++ b/pkg/sdkv2/resources/environment.go
@@ -51,13 +51,10 @@ func ResourceEnvironment() *schema.Resource {
 				Description: "Environment name",
 			},
 			"dbt_version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "latest",
-				Description: "Version number of dbt to use in this environment. " +
-					"It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), " +
-					"`major.minor.0-pre`, `versionless`, or `latest`. While `versionless` is still supported, " +
-					"using `latest` is recommended. Defaults to`latest` if no version is provided",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "latest",
+				Description: "Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `versionless`, or `latest`. While `versionless` is still supported, using `latest` is recommended. Defaults to `latest` if no version is provided",
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 					if (oldValue == "latest" || oldValue == "versionless") &&
 						(newValue == "latest" || newValue == "versionless") {

--- a/pkg/sdkv2/resources/environment.go
+++ b/pkg/sdkv2/resources/environment.go
@@ -56,11 +56,14 @@ func ResourceEnvironment() *schema.Resource {
 				Default:     "latest",
 				Description: "Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `versionless`, or `latest`. While `versionless` is still supported, using `latest` is recommended. Defaults to `latest` if no version is provided",
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-					if (oldValue == "latest" || oldValue == "versionless") &&
-						(newValue == "latest" || newValue == "versionless") {
-						return true
+					switch oldValue {
+					case "versionless":
+						return newValue == "latest"
+					case "latest":
+						return newValue == "versionless"
+					default:
+						return false
 					}
-					return false
 				},
 			},
 			"type": {

--- a/pkg/sdkv2/resources/environment_acceptance_test.go
+++ b/pkg/sdkv2/resources/environment_acceptance_test.go
@@ -17,6 +17,7 @@ import (
 // testing for the historical use case where connection_id is not configured at the env level
 func TestAccDbtCloudEnvironmentResourceNoConnection(t *testing.T) {
 
+	dbtVersionLatest := "latest"
 	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	environmentName2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
@@ -30,6 +31,7 @@ func TestAccDbtCloudEnvironmentResourceNoConnection(t *testing.T) {
 				Config: testAccDbtCloudEnvironmentResourceNoConnectionBasicConfig(
 					projectName,
 					environmentName,
+					dbtVersionLatest,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDbtCloudEnvironmentExists("dbtcloud_environment.test_env"),
@@ -50,6 +52,7 @@ func TestAccDbtCloudEnvironmentResourceNoConnection(t *testing.T) {
 				Config: testAccDbtCloudEnvironmentResourceNoConnectionBasicConfig(
 					projectName,
 					environmentName2,
+					dbtVersionLatest,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDbtCloudEnvironmentExists("dbtcloud_environment.test_env"),
@@ -78,7 +81,7 @@ func TestAccDbtCloudEnvironmentResourceNoConnection(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"dbtcloud_environment.test_env",
 						"dbt_version",
-						DBT_CLOUD_VERSION,
+						dbtVersionLatest,
 					),
 					resource.TestCheckResourceAttr(
 						"dbtcloud_environment.test_env",
@@ -124,7 +127,7 @@ func TestAccDbtCloudEnvironmentResourceNoConnection(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"dbtcloud_environment.test_env",
 						"dbt_version",
-						DBT_CLOUD_VERSION,
+						dbtVersionLatest,
 					),
 					resource.TestCheckResourceAttr(
 						"dbtcloud_environment.test_env",
@@ -159,7 +162,9 @@ func TestAccDbtCloudEnvironmentResourceNoConnection(t *testing.T) {
 }
 
 func testAccDbtCloudEnvironmentResourceNoConnectionBasicConfig(
-	projectName, environmentName string,
+	projectName string,
+	environmentName string,
+	dbtVersion string,
 ) string {
 	return fmt.Sprintf(`
 resource "dbtcloud_project" "test_project" {
@@ -173,7 +178,7 @@ resource "dbtcloud_environment" "test_env" {
   project_id = dbtcloud_project.test_project.id
   deployment_type = "production"
 }
-`, projectName, environmentName, DBT_CLOUD_VERSION)
+`, projectName, environmentName, dbtVersion)
 }
 
 func testAccDbtCloudEnvironmentResourceNoConnectionModifiedConfig(
@@ -206,6 +211,7 @@ resource "dbtcloud_bigquery_credential" "test_credential" {
 
 // testing for the global connection use case where connection_id is added at the env level
 func TestAccDbtCloudEnvironmentResourceConnection(t *testing.T) {
+	dbtVersionLatest := "latest"
 	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	environmentName2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
@@ -219,6 +225,7 @@ func TestAccDbtCloudEnvironmentResourceConnection(t *testing.T) {
 				Config: testAccDbtCloudEnvironmentResourceConnectionBasicConfig(
 					projectName,
 					environmentName,
+					dbtVersionLatest,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDbtCloudEnvironmentExists("dbtcloud_environment.test_env"),
@@ -239,6 +246,7 @@ func TestAccDbtCloudEnvironmentResourceConnection(t *testing.T) {
 				Config: testAccDbtCloudEnvironmentResourceConnectionBasicConfig(
 					projectName,
 					environmentName2,
+					dbtVersionLatest,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDbtCloudEnvironmentExists("dbtcloud_environment.test_env"),
@@ -256,6 +264,7 @@ func TestAccDbtCloudEnvironmentResourceConnection(t *testing.T) {
 					environmentName2,
 					"",
 					"false",
+					dbtVersionLatest,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDbtCloudEnvironmentExists("dbtcloud_environment.test_env"),
@@ -267,7 +276,7 @@ func TestAccDbtCloudEnvironmentResourceConnection(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"dbtcloud_environment.test_env",
 						"dbt_version",
-						DBT_CLOUD_VERSION,
+						dbtVersionLatest,
 					),
 					resource.TestCheckResourceAttr(
 						"dbtcloud_environment.test_env",
@@ -297,6 +306,7 @@ func TestAccDbtCloudEnvironmentResourceConnection(t *testing.T) {
 					environmentName2,
 					"main",
 					"true",
+					dbtVersionLatest,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDbtCloudEnvironmentExists("dbtcloud_environment.test_env"),
@@ -308,7 +318,7 @@ func TestAccDbtCloudEnvironmentResourceConnection(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"dbtcloud_environment.test_env",
 						"dbt_version",
-						DBT_CLOUD_VERSION,
+						dbtVersionLatest,
 					),
 					resource.TestCheckResourceAttr(
 						"dbtcloud_environment.test_env",
@@ -339,7 +349,9 @@ func TestAccDbtCloudEnvironmentResourceConnection(t *testing.T) {
 }
 
 func testAccDbtCloudEnvironmentResourceConnectionBasicConfig(
-	projectName, environmentName string,
+	projectName string,
+	environmentName string,
+	dbtVersion string,
 ) string {
 	return fmt.Sprintf(`
 resource "dbtcloud_project" "test_project" {
@@ -367,11 +379,15 @@ resource "dbtcloud_environment" "test_env" {
   connection_id = dbtcloud_global_connection.test.id
   }
   
-  `, projectName, environmentName, DBT_CLOUD_VERSION)
+  `, projectName, environmentName, dbtVersion)
 }
 
 func testAccDbtCloudEnvironmentResourceConnectionModifiedConfig(
-	projectName, environmentName, customBranch, useCustomBranch string,
+	projectName string,
+	environmentName string,
+	customBranch string,
+	useCustomBranch string,
+	dbtVersion string,
 ) string {
 	return fmt.Sprintf(`
 resource "dbtcloud_project" "test_project" {
@@ -419,7 +435,38 @@ resource "dbtcloud_bigquery_credential" "test_credential" {
 	num_threads = 16
   }
   
-`, projectName, environmentName, DBT_CLOUD_VERSION, customBranch, useCustomBranch)
+`, projectName, environmentName, dbtVersion, customBranch, useCustomBranch)
+}
+
+// TestAccDbtCloudEnvironmentResourceVersionless tests the environment resource with dbt_version set to versionless
+// This is a special case where if the dbt_version is set to `versionless`, the dbt Cloud API may return `latest`
+func TestAccDbtCloudEnvironmentResourceVersionless(t *testing.T) {
+	dbtVersionless := "versionless"
+	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDbtCloudEnvironmentResourceNoConnectionBasicConfig(
+					projectName,
+					environmentName,
+					dbtVersionless,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudEnvironmentExists("dbtcloud_environment.test_env"),
+					resource.TestMatchResourceAttr(
+						"dbtcloud_environment.test_env",
+						"dbt_version",
+						regexp.MustCompile("^versionless|latest$"),
+					),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckDbtCloudEnvironmentExists(resource string) resource.TestCheckFunc {

--- a/pkg/sdkv2/resources/environment_acceptance_test.go
+++ b/pkg/sdkv2/resources/environment_acceptance_test.go
@@ -162,9 +162,7 @@ func TestAccDbtCloudEnvironmentResourceNoConnection(t *testing.T) {
 }
 
 func testAccDbtCloudEnvironmentResourceNoConnectionBasicConfig(
-	projectName string,
-	environmentName string,
-	dbtVersion string,
+	projectName, environmentName, dbtVersion string,
 ) string {
 	return fmt.Sprintf(`
 resource "dbtcloud_project" "test_project" {
@@ -349,9 +347,7 @@ func TestAccDbtCloudEnvironmentResourceConnection(t *testing.T) {
 }
 
 func testAccDbtCloudEnvironmentResourceConnectionBasicConfig(
-	projectName string,
-	environmentName string,
-	dbtVersion string,
+	projectName, environmentName, dbtVersion string,
 ) string {
 	return fmt.Sprintf(`
 resource "dbtcloud_project" "test_project" {
@@ -383,11 +379,7 @@ resource "dbtcloud_environment" "test_env" {
 }
 
 func testAccDbtCloudEnvironmentResourceConnectionModifiedConfig(
-	projectName string,
-	environmentName string,
-	customBranch string,
-	useCustomBranch string,
-	dbtVersion string,
+	projectName, environmentName, customBranch, useCustomBranch, dbtVersion string,
 ) string {
 	return fmt.Sprintf(`
 resource "dbtcloud_project" "test_project" {

--- a/pkg/sdkv2/resources/helpers_test.go
+++ b/pkg/sdkv2/resources/helpers_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DBT_CLOUD_VERSION = "versionless"
+	DBT_CLOUD_VERSION = "latest"
 )
 
 var testAccProviders map[string]*schema.Provider

--- a/templates/guides/1_getting_started.md
+++ b/templates/guides/1_getting_started.md
@@ -99,7 +99,7 @@ resource "dbtcloud_project_repository" "my_project_repository" {
 // here both are linked to the same Data Warehouse connection
 // for Prod, we need to create a credential as well
 resource "dbtcloud_environment" "my_dev" {
-  dbt_version     = "versionless"
+  dbt_version     = "latest"
   name            = "Dev"
   project_id      = dbtcloud_project.my_project.id
   type            = "development"
@@ -107,7 +107,7 @@ resource "dbtcloud_environment" "my_dev" {
 }
 
 resource "dbtcloud_environment" "my_prod" {
-  dbt_version     = "versionless"
+  dbt_version     = "latest"
   name            = "Prod"
   project_id      = dbtcloud_project.my_project.id
   type            = "deployment"


### PR DESCRIPTION
Updates the environment resource's dbt_version field to suppress the diff between `versionless` and `latest`, so they are treat as equivalents when a comparison is performed.  It also updates the default value for the environment resource's dbt_version to `latest`, which should be backward compatible.

This change was made because the provider's acceptance tests are using `versionless`, and recently the dbt Cloud API began returning `latest`, which caused the [tests to fail](https://github.com/dbt-labs/terraform-provider-dbtcloud/actions/runs/12286985091/job/34325784094).

Resolves https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/320 