### PR TITLE
fix: prevent environment connection id from being overwritten when project is updated

### DIFF
--- a/pkg/sdkv2/resources/environment_acceptance_test.go
+++ b/pkg/sdkv2/resources/environment_acceptance_test.go
@@ -2,7 +2,6 @@ package resources_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"regexp"
 	"strconv"
 	"strings"
@@ -372,7 +371,6 @@ func TestAccDbtCloudEnvironmentResourceProjectUpdate(t *testing.T) {
 					environmentNameProd,
 					dbtVersionLatest,
 				),
-				ConfigStateChecks: []statecheck.StateCheck{},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDbtCloudEnvironmentExists("dbtcloud_environment.dev"),
 					testAccCheckDbtCloudEnvironmentExists("dbtcloud_environment.prod"),

--- a/pkg/sdkv2/resources/project.go
+++ b/pkg/sdkv2/resources/project.go
@@ -112,6 +112,13 @@ func resourceProjectUpdate(
 	if d.HasChange("name") || d.HasChange("description") ||
 		d.HasChange("dbt_project_subdirectory") {
 		project, err := c.GetProject(projectID)
+
+		// When updating a project, the connection ID should always be excluded.
+		// With the introduction of global connections, if a connection ID is passed in this update request,
+		// the connection ID will be cascaded to all environments in the project and will override any
+		// existing connection IDs on those environments.
+		project.ConnectionID = nil
+
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/334

### What was happening?
When the provider performs an update on the project, it first retrieves the existing project data from the API then updates that object with any modified fields. Since the project retrieved from the API includes the development connection's ID, that `connection_id` is sent back in the update request to dbt Cloud. When global connections were introduced, the project API was updated to cascade any included `connection_id` to all environments in the project. In this case, it was causing the `PROD` environment's connection to be incorrectly overwritten with the dev connection.

### The fix
When the existing project information is read by the update handler, we can remove the `connection_id` so it won't be passed back with the update request. This prevents any connection information from being updated on any environment in the project.

### Acceptance Test
Before the fix, the test included in this PR would fail with the following error:
```
=== RUN   TestAccDbtCloudEnvironmentResourceProjectUpdate
    environment_acceptance_test.go:359: Step 2/3 error: After applying this test step, the refresh plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # dbtcloud_environment.prod will be updated in-place
          ~ resource "dbtcloud_environment" "prod" {
              ~ connection_id              = 35218731828221 -> 35218731828220
                id                         = "35218731829989:35218731828337"
                name                       = "RSMJCCKTKF prod"
                # (11 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccDbtCloudEnvironmentResourceProjectUpdate (12.40s)
FAIL
FAIL    github.com/dbt-labs/terraform-provider-dbtcloud/pkg/sdkv2/resources     12.884s
FAIL
```