### PR TITLE
PR with a few fixes to be released in 0.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.23...HEAD)
+## [Unreleased](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.24...HEAD)
+
+# [0.3.24](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.23...v0.3.24)
+
+### Fixes
+- force new resource for any change to `dbtcloud_service_token` since the API was updated to prevent changes to existing tokens [#343](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/343)
+- add the ability to define a specific `job_type` independently of the triggers [#345](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/345)
+- add the ability to define a specific `compare_changes_flags` in `dbtcloud_job` [#341](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/341)
 
 # [0.3.23](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.22...v0.3.23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - add the ability to define a specific `job_type` independently of the triggers [#345](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/345)
 - add the ability to define a specific `compare_changes_flags` in `dbtcloud_job` [#341](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/341)
 
+
+### Behind the scenes
+- Fix CI pipeline
+
 # [0.3.23](https://github.com/dbt-labs/terraform-provider-dbtcloud/compare/v0.3.22...v0.3.23)
 
 ### Changes

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -116,6 +116,7 @@ resource "dbtcloud_job" "downstream_job" {
 
 ### Optional
 
+- `compare_changes_flags` (String) The model selector for checking changes in the compare changes Advanced CI feature
 - `dbt_version` (String) Version number of dbt to use in this job, usually in the format 1.2.0-latest rather than core versions
 - `deferring_environment_id` (Number) Environment identifier that this job defers to (new deferring approach)
 - `deferring_job_id` (Number) Job identifier that this job defers to (legacy deferring approach)
@@ -124,6 +125,7 @@ resource "dbtcloud_job" "downstream_job" {
 - `generate_docs` (Boolean) Flag for whether the job should generate documentation
 - `is_active` (Boolean) Should always be set to true as setting it to false is the same as creating a job in a deleted state. To create/keep a job in a 'deactivated' state, check  the `triggers` config.
 - `job_completion_trigger_condition` (Block Set, Max: 1) Which other job should trigger this job when it finishes, and on which conditions (sometimes referred as 'job chaining'). (see [below for nested schema](#nestedblock--job_completion_trigger_condition))
+- `job_type` (String) Can be used to enforce the job type betwen `ci`, `merge` and `scheduled`. Without this value the job type is inferred from the triggers configured
 - `num_threads` (Number) Number of threads to use in the job
 - `run_compare_changes` (Boolean) Whether the CI job should compare data changes introduced by the code changes. Requires `deferring_environment_id` to be set. (Advanced CI needs to be activated in the dbt Cloud Account Settings first as well)
 - `run_generate_sources` (Boolean) Flag for whether the job should add a `dbt source freshness` step to the job. The difference between manually adding a step with `dbt source freshness` in the job steps or using this flag is that with this flag, a failed freshness will still allow the following steps to run.

--- a/pkg/sdkv2/data_sources/webhook_acceptance_test.go
+++ b/pkg/sdkv2/data_sources/webhook_acceptance_test.go
@@ -52,7 +52,7 @@ func webhooks(webhookName string, webhookDesc string) string {
     resource "dbtcloud_webhook" "test_webhook" {
         name = "%s"
         description = "%s"
-        client_url = "http://localhost/nothing"
+        client_url = "https://example.com/test"
         event_types = [
             "job.run.started",
             "job.run.completed"

--- a/pkg/sdkv2/resources/job_acceptance_test.go
+++ b/pkg/sdkv2/resources/job_acceptance_test.go
@@ -766,3 +766,76 @@ func testAccCheckDbtCloudJobDestroy(s *terraform.State) error {
 
 	return nil
 }
+
+func TestAccDbtCloudJobResourceJobTypeAndCompareChanges(t *testing.T) {
+	jobName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDbtCloudJobResourceJobTypeAndCompareChangesConfig(
+					jobName,
+					projectName,
+					environmentName,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "name", jobName),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "job_type", "ci"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "compare_changes_flags", "--select state:modified+"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "triggers.github_webhook", "false"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "triggers.git_provider_webhook", "false"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "triggers.schedule", "false"),
+				),
+			},
+			// IMPORT
+			{
+				ResourceName:      "dbtcloud_job.test_job",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"triggers.%",
+					"triggers.custom_branch_only",
+				},
+			},
+		},
+	})
+}
+
+func testAccDbtCloudJobResourceJobTypeAndCompareChangesConfig(jobName, projectName, environmentName string) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_project" "test_job_project" {
+    name = "%s"
+}
+
+resource "dbtcloud_environment" "test_job_environment" {
+    project_id = dbtcloud_project.test_job_project.id
+    name = "%s"
+    dbt_version = "%s"
+    type = "deployment"
+}
+
+resource "dbtcloud_job" "test_job" {
+    name = "%s"
+    project_id = dbtcloud_project.test_job_project.id
+    environment_id = dbtcloud_environment.test_job_environment.environment_id
+	deferring_environment_id = dbtcloud_environment.test_job_environment.environment_id
+    execute_steps = [
+        "dbt build"
+    ]
+    triggers = {
+        "github_webhook": false,
+        "git_provider_webhook": false,
+        "schedule": false
+    }
+    job_type = "ci"
+    run_compare_changes = true
+    compare_changes_flags = "--select state:modified+"
+}
+`, projectName, environmentName, DBT_CLOUD_VERSION, jobName)
+}

--- a/pkg/sdkv2/resources/webhook_acceptance_test.go
+++ b/pkg/sdkv2/resources/webhook_acceptance_test.go
@@ -56,7 +56,7 @@ func TestAccDbtCloudWebhookResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"dbtcloud_webhook.test_webhook",
 						"client_url",
-						"http://localhost/nothing",
+						"https://example.com",
 					),
 				),
 			},
@@ -91,7 +91,7 @@ func TestAccDbtCloudWebhookResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"dbtcloud_webhook.test_webhook",
 						"client_url",
-						"http://localhost/new-nothing",
+						"https://example.com/test",
 					),
 				),
 			},
@@ -116,7 +116,7 @@ resource "dbtcloud_project" "test_project" {
 resource "dbtcloud_webhook" "test_webhook" {
 	name = "%s"
 	description = "My webhook"
-	client_url = "http://localhost/nothing"
+	client_url = "https://example.com"
 	event_types = [
 	  "job.run.started",
 	  "job.run.completed"
@@ -157,7 +157,7 @@ resource "dbtcloud_job" "test" {
 resource "dbtcloud_webhook" "test_webhook" {
 	name = "%s"
 	description = "My webhook"
-	client_url = "http://localhost/new-nothing"
+	client_url = "https://example.com/test"
 	event_types = [
 	  "job.run.completed"
 	]


### PR DESCRIPTION
### Fixes
- force new resource for any change to `dbtcloud_service_token` since the API was updated to prevent changes to existing tokens [#343](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/343)
- add the ability to define a specific `job_type` independently of the triggers [#345](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/345)
- add the ability to define a specific `compare_changes_flags` in `dbtcloud_job` [#341](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/341)