### PR TITLE
Do not update the connection linked to the project when updating repos

### DIFF
--- a/pkg/sdkv2/resources/project_repository.go
+++ b/pkg/sdkv2/resources/project_repository.go
@@ -59,6 +59,10 @@ func resourceProjectRepositoryCreate(
 		return diag.FromErr(err)
 	}
 
+	// Issue #362
+	// we don't want to update the connection ID when we set a project otherwise it will update all envs
+	project.ConnectionID = nil
+
 	project.RepositoryID = &repositoryID
 
 	_, err = c.UpdateProject(projectIDString, *project)
@@ -124,6 +128,10 @@ func resourceProjectRepositoryDelete(
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Issue #362
+	// we don't want to update the connection ID when we set a project otherwise it will update all envs
+	project.ConnectionID = nil
 
 	project.RepositoryID = nil
 


### PR DESCRIPTION
Fixes #362

Hi team. I tested locally that before the update I was able to replicate the issue and it disappears with the fix of this PR.
I didn't add a specific acceptance test about it, but we could if we think it is required. It would just require setting quite a few resources (1 project, 2 envs, 1 repo and 1 project_repo)