### PR TITLE
Support Type setting of dbtcloud_project resource

### DIFF
--- a/pkg/dbt_cloud/project.go
+++ b/pkg/dbt_cloud/project.go
@@ -13,6 +13,7 @@ type Project struct {
 	Name                   string  `json:"name"`
 	Description            string  `json:"description"`
 	DbtProjectSubdirectory *string `json:"dbt_project_subdirectory,omitempty"`
+	DbtProjectType         int     `json:"type"`
 	ConnectionID           *int    `json:"connection_id,omitempty"`
 	RepositoryID           *int    `json:"repository_id,omitempty"`
 	State                  int     `json:"state"`
@@ -152,12 +153,14 @@ func (c *Client) CreateProject(
 	name string,
 	description string,
 	dbtProjectSubdirectory string,
+	dbtProjectType int,
 ) (*Project, error) {
 	newProject := Project{
-		Name:        name,
-		Description: description,
-		State:       STATE_ACTIVE,
-		AccountID:   c.AccountID,
+		Name:           name,
+		Description:    description,
+		State:          STATE_ACTIVE,
+		AccountID:      c.AccountID,
+		Type:           dbtProjectType,
 	}
 	if dbtProjectSubdirectory != "" {
 		newProject.DbtProjectSubdirectory = &dbtProjectSubdirectory

--- a/pkg/dbt_cloud/project.go
+++ b/pkg/dbt_cloud/project.go
@@ -160,7 +160,7 @@ func (c *Client) CreateProject(
 		Description:    description,
 		State:          STATE_ACTIVE,
 		AccountID:      c.AccountID,
-		Type:           dbtProjectType,
+		DbtProjectType: dbtProjectType,
 	}
 	if dbtProjectSubdirectory != "" {
 		newProject.DbtProjectSubdirectory = &dbtProjectSubdirectory

--- a/pkg/framework/objects/project/data_source.go
+++ b/pkg/framework/objects/project/data_source.go
@@ -144,6 +144,7 @@ func (d *projectDataSource) Read(
 	}
 
 	state.State = types.Int64Value(int64(project.State))
+	state.DbtProjectType = types.Int64Value(int64(project.DbtProjectType))
 
 	// Set state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/pkg/framework/objects/project/data_source_all.go
+++ b/pkg/framework/objects/project/data_source_all.go
@@ -66,6 +66,9 @@ func (d *projectsDataSource) Read(
 		currentProject.DbtProjectSubdirectory = types.StringValue(
 			project.DbtProjectSubdirectory,
 		)
+		currentProject.DbtProjectType = types.Int64Value(
+			project.DbtProjectType,
+		)
 		currentProject.CreatedAt = types.StringValue(project.CreatedAt)
 		currentProject.UpdatedAt = types.StringValue(project.UpdatedAt)
 

--- a/pkg/framework/objects/project/data_source_all.go
+++ b/pkg/framework/objects/project/data_source_all.go
@@ -66,9 +66,6 @@ func (d *projectsDataSource) Read(
 		currentProject.DbtProjectSubdirectory = types.StringValue(
 			project.DbtProjectSubdirectory,
 		)
-		currentProject.DbtProjectType = types.Int64Value(
-			project.DbtProjectType,
-		)
 		currentProject.CreatedAt = types.StringValue(project.CreatedAt)
 		currentProject.UpdatedAt = types.StringValue(project.UpdatedAt)
 

--- a/pkg/framework/objects/project/model.go
+++ b/pkg/framework/objects/project/model.go
@@ -25,6 +25,7 @@ type ProjectDataSourceModel struct {
 	Description            types.String       `tfsdk:"description"`
 	SemanticLayerConfigID  types.Int64        `tfsdk:"semantic_layer_config_id"`
 	DbtProjectSubdirectory types.String       `tfsdk:"dbt_project_subdirectory"`
+	DbtProjectType         types.Int64        `tfsdk:"type"`
 	CreatedAt              types.String       `tfsdk:"created_at"`
 	UpdatedAt              types.String       `tfsdk:"updated_at"`
 	ProjectConnection      *ProjectConnection `tfsdk:"project_connection"`
@@ -51,4 +52,5 @@ type ProjectResourceModel struct {
 	Name                   types.String `tfsdk:"name"`
 	Description            types.String `tfsdk:"description"`
 	DbtProjectSubdirectory types.String `tfsdk:"dbt_project_subdirectory"`
+	DbtProjectType         types.Int64  `tfsdk:"type"`
 }

--- a/pkg/framework/objects/project/resource.go
+++ b/pkg/framework/objects/project/resource.go
@@ -76,8 +76,13 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 		dbtProjectSubdirectory = plan.DbtProjectSubdirectory.ValueString()
 	}
 
-	// Call CreateProject with the correct signature (string, string, string)
-	project, err := r.client.CreateProject(name, description, dbtProjectSubdirectory)
+	dbtProjectType := 0
+	if !plan.DbtProjectType.IsNull() {
+		dbtProjectType = plan.DbtProjectType.ValueInt64()
+	}
+
+	// Call CreateProject with the correct signature (string, string, string, int)
+	project, err := r.client.CreateProject(name, description, dbtProjectSubdirectory, dbtProjectType)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating project",
@@ -95,6 +100,8 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	} else {
 		plan.DbtProjectSubdirectory = types.StringNull()
 	}
+
+	plan.DbtProjectType = types.Int64Value(project.DbtProjectType)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)
@@ -141,6 +148,8 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	} else {
 		state.DbtProjectSubdirectory = types.StringNull()
 	}
+
+	state.DbtProjectType = types.Int64Value(project.DbtProjectType)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
@@ -199,6 +208,11 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		updateProject.DbtProjectSubdirectory = &dbtProjectSubdir
 	}
 
+	if !plan.DbtProjectType.IsNull() {
+		dbtProjectType := plan.DbtProjectType.ValueInt64()
+		updateProject.DbtProjectType = &dbtProjectType
+	}
+
 	// When updating a project, the connection ID should always be excluded.
 	// With the introduction of global connections, if a connection ID is passed in this update request,
 	// the connection ID will be cascaded to all environments in the project and will override any
@@ -224,6 +238,8 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 	} else {
 		plan.DbtProjectSubdirectory = types.StringNull()
 	}
+
+	plan.DbtProjectType = types.Int64Value(project.DbtProjectType)
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/pkg/framework/objects/project/resource_acceptance_test.go
+++ b/pkg/framework/objects/project/resource_acceptance_test.go
@@ -56,7 +56,7 @@ var modifyStep = resource.TestStep{
 			"dbtcloud_project.test_project",
 			"type",
 			0,
-		)
+		),
 	),
 }
 

--- a/pkg/framework/objects/project/resource_acceptance_test.go
+++ b/pkg/framework/objects/project/resource_acceptance_test.go
@@ -52,6 +52,11 @@ var modifyStep = resource.TestStep{
 			"dbt_project_subdirectory",
 			"/project/subdirectory_where/dbt-is",
 		),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_project.test_project",
+			"type",
+			0,
+		)
 	),
 }
 
@@ -92,6 +97,7 @@ resource "dbtcloud_project" "test_project" {
   name = "%s"
   description = "%s"
   dbt_project_subdirectory = "/project/subdirectory_where/dbt-is"
+  type = 0
 }
 `, projectName, projectDescription)
 }


### PR DESCRIPTION
Resolves issue #398 by adding support for `type` in the `dbtcloud_project` resource. 