### PR TITLE
Check if fields are unknown before asessing if they are null or empty

### DIFF
--- a/pkg/framework/objects/snowflake_credential/validators/sl_cred_validator.go
+++ b/pkg/framework/objects/snowflake_credential/validators/sl_cred_validator.go
@@ -21,34 +21,47 @@ func (v SemanticLayerCredentialValidator) ValidateBool(ctx context.Context, req 
 
 	// Check if `semantic_layer_credential` is false
 	if !req.ConfigValue.ValueBool() || req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
-		// Validate that `user` is provided
-		var userValue types.String
-		userPath := req.Path.ParentPath().AtName("user")
-		diags := req.Config.GetAttribute(ctx, userPath, &userValue)
+		var semantic_layer_enabled types.Bool
+		semanticLayerPath := req.Path.ParentPath().AtName("semantic_layer_credential")
+		diags := req.Config.GetAttribute(ctx, semanticLayerPath, &semantic_layer_enabled)
 		if diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
 		}
-		if userValue.IsNull() || userValue.IsUnknown() {
-			resp.Diagnostics.AddError(
-				"Missing Required Attribute",
-				"`user` must be provided when `semantic_layer_credential` is false.",
-			)
-		}
+		if semantic_layer_enabled.IsNull() || !semantic_layer_enabled.ValueBool() {
+			// Validate that `user` is provided
+			var userValue types.String
+			userPath := req.Path.ParentPath().AtName("user")
+			diags = req.Config.GetAttribute(ctx, userPath, &userValue)
+			if diags.HasError() {
+				resp.Diagnostics.Append(diags...)
+				return
+			}
+			if !userValue.IsUnknown() {
+				if userValue.IsNull() || userValue.ValueString() == "" {
+					resp.Diagnostics.AddError(
+						"Missing Required Attribute",
+						"`user` must be provided when `semantic_layer_credential` is false.",
+					)
+				}
+			}
 
-		// Validate that `schema` is provided
-		var schemaValue types.String
-		schemaPath := req.Path.ParentPath().AtName("schema")
-		diags = req.Config.GetAttribute(ctx, schemaPath, &schemaValue)
-		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-		if schemaValue.IsNull() || schemaValue.IsUnknown() {
-			resp.Diagnostics.AddError(
-				"Missing Required Attribute",
-				"`schema` must be provided when `semantic_layer_credential` is false.",
-			)
+			// Validate that `schema` is provided
+			var schemaValue types.String
+			schemaPath := req.Path.ParentPath().AtName("schema")
+			diags = req.Config.GetAttribute(ctx, schemaPath, &schemaValue)
+			if diags.HasError() {
+				resp.Diagnostics.Append(diags...)
+				return
+			}
+			if !schemaValue.IsUnknown() {
+				if schemaValue.IsNull() || schemaValue.ValueString() == "" {
+					resp.Diagnostics.AddError(
+						"Missing Required Attribute",
+						"`schema` must be provided when `semantic_layer_credential` is false.",
+					)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
The issue described [here](https://github.com/dbt-labs/terraform-provider-dbtcloud/issues/421) is that the `user` and `schema` fields are being validated while still unknown.
Added an extra check in the semantic layer credential validation to check if the fields are known. 