### PR TITLE
AD-HOC Allow Unit Tests to be run manually

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 name: dbt Cloud Integration Tests
 


### PR DESCRIPTION
Will allow us to manually test the codebase without relying on the scheduled runs or PRs.