### PR TITLE
Dbtcloud repository when applying the same configuration

### DIFF
--- a/.changes/unreleased/Fixes-20250523-113025.yaml
+++ b/.changes/unreleased/Fixes-20250523-113025.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Obfuscate error messages from the API that would display the token
+time: 2025-05-23T11:30:25.971905+03:00

--- a/.changes/unreleased/Fixes-20250523-194042.yaml
+++ b/.changes/unreleased/Fixes-20250523-194042.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: 'Fix repository create and apply to be consistent with multiple applies. Issue #433'
+time: 2025-05-23T19:40:42.002758+03:00

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -106,9 +106,9 @@ resource "dbtcloud_repository" "ado_repo" {
 - `fetch_deploy_key` (Boolean, Deprecated) Whether we should return the public deploy key - (for the `deploy_key` strategy)
 - `git_clone_strategy` (String) Git clone strategy for the repository. Can be `deploy_key` (default) for cloning via SSH Deploy Key, `github_app` for GitHub native integration, `deploy_token` for the GitLab native integration and `azure_active_directory_app` for ADO native integration
 - `github_installation_id` (Number) Identifier for the GitHub App - (for GitHub native integration only)
-- `gitlab_project_id` (Number) Identifier for the Gitlab project - (for GitLab native integration only)
+- `gitlab_project_id` (Number) Identifier for the Gitlab project -  (for GitLab native integration only)
 - `is_active` (Boolean) Whether the repository is active
-- `pull_request_url_template` (String) The pull request URL template to be used when opening a pull request from within dbt Cloud's IDE
+- `pull_request_url_template` (String) URL template for creating a pull request. If it is not set, the default template will create a PR from the current branch to the branch configured in the Development environment.
 
 ### Read-Only
 

--- a/pkg/dbt_cloud/client.go
+++ b/pkg/dbt_cloud/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -181,12 +182,21 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 	if (res.StatusCode != http.StatusOK) &&
 		(res.StatusCode != http.StatusCreated) &&
 		(res.StatusCode != http.StatusNoContent) {
+		
+		urlStr := req.URL.String()
+		bodyStr := string(body)
+
+		if c.Token != "" {
+			urlStr = strings.ReplaceAll(urlStr, c.Token, "[REDACTED_TOKEN]")
+			bodyStr = strings.ReplaceAll(bodyStr, c.Token, "[REDACTED_TOKEN]")
+		}
+		
 		return nil, fmt.Errorf(
 			"%s url: %s, status: %d, body: %s",
 			req.Method,
-			req.URL,
+			urlStr,
 			res.StatusCode,
-			body,
+			bodyStr,
 		)
 	}
 

--- a/pkg/framework/objects/repository/resource.go
+++ b/pkg/framework/objects/repository/resource.go
@@ -259,9 +259,7 @@ func (r *repositoryResource) Read(
 
 	if repository.GitlabProjectID != nil {
 		state.GitlabProjectID = types.Int64Value(int64(*repository.GitlabProjectID))
-	} else {
-		state.GitlabProjectID = types.Int64Null()
-	}
+	} 
 
 	if repository.GithubInstallationID != nil {
 		state.GithubInstallationID = types.Int64Value(int64(*repository.GithubInstallationID))
@@ -410,9 +408,7 @@ func (r *repositoryResource) Update(
 
 	if repository.GitlabProjectID != nil {
 		plan.GitlabProjectID = types.Int64Value(int64(*repository.GitlabProjectID))
-	} else {
-		plan.GitlabProjectID = types.Int64Null()
-	}
+	} 
 
 	if repository.GithubInstallationID != nil {
 		plan.GithubInstallationID = types.Int64Value(int64(*repository.GithubInstallationID))

--- a/pkg/framework/objects/repository/resource.go
+++ b/pkg/framework/objects/repository/resource.go
@@ -257,11 +257,9 @@ func (r *repositoryResource) Read(
 		state.RepositoryCredentialsID = types.Int64Null()
 	}
 
-	if repository.GitlabProjectID != nil {
+	if repository.GitlabProjectID != nil { // GitlabProjectID is not returned by the api for the moment, it always return null
 		state.GitlabProjectID = types.Int64Value(int64(*repository.GitlabProjectID))
-	}else {
-		state.GitlabProjectID = types.Int64Null()
-	} 
+	}
 
 	if repository.GithubInstallationID != nil {
 		state.GithubInstallationID = types.Int64Value(int64(*repository.GithubInstallationID))

--- a/pkg/framework/objects/repository/schema.go
+++ b/pkg/framework/objects/repository/schema.go
@@ -4,6 +4,8 @@ import (
 	datasource_schema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -34,16 +36,25 @@ func ResourceSchema() resource_schema.Schema {
 			"project_id": resource_schema.Int64Attribute{
 				Required:    true,
 				Description: "Project ID to create the repository in",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
 			},
 			"remote_url": resource_schema.StringAttribute{
 				Required:    true,
 				Description: "Git URL for the repository or \\<Group>/\\<Project> for Gitlab",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"git_clone_strategy": resource_schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString("deploy_key"),
 				Description: "Git clone strategy for the repository. Can be `deploy_key` (default) for cloning via SSH Deploy Key, `github_app` for GitHub native integration, `deploy_token` for the GitLab native integration and `azure_active_directory_app` for ADO native integration",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"repository_credentials_id": resource_schema.Int64Attribute{
 				Computed:    true,
@@ -51,25 +62,44 @@ func ResourceSchema() resource_schema.Schema {
 			},
 			"gitlab_project_id": resource_schema.Int64Attribute{
 				Optional:    true,
-				Description: "Identifier for the Gitlab project - (for GitLab native integration only)",
+				Description: "Identifier for the Gitlab project -  (for GitLab native integration only)",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
 			},
 			"github_installation_id": resource_schema.Int64Attribute{
 				Optional:    true,
 				Description: "Identifier for the GitHub App - (for GitHub native integration only)",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
 			},
 			"azure_active_directory_project_id": resource_schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 				Description: "The Azure Dev Ops project ID. It can be retrieved via the Azure API or using the data source `dbtcloud_azure_dev_ops_project` and the project name - (for ADO native integration only)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"azure_active_directory_repository_id": resource_schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 				Description: "The Azure Dev Ops repository ID. It can be retrieved via the Azure API or using the data source `dbtcloud_azure_dev_ops_repository` along with the ADO Project ID and the repository name - (for ADO native integration only)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"azure_bypass_webhook_registration_failure": resource_schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(false),
 				Description: "If set to False (the default), the connection will fail if the service user doesn't have access to set webhooks (required for auto-triggering CI jobs). If set to True, the connection will be successful but no automated CI job will be triggered - (for ADO native integration only)",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
 			"fetch_deploy_key": resource_schema.BoolAttribute{
 				Optional:           true,
@@ -85,7 +115,7 @@ func ResourceSchema() resource_schema.Schema {
 			"pull_request_url_template": resource_schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "The pull request URL template to be used when opening a pull request from within dbt Cloud's IDE",
+				Description: "URL template for creating a pull request. If it is not set, the default template will create a PR from the current branch to the branch configured in the Development environment.",
 			},
 		},
 	}


### PR DESCRIPTION
- Added obfuscation to output messages for the dbt token
- GitlabProjectID is not set to null on Read()
- Marked fields for `require replace` so the repository is recreated in dbt cloud when updating