### PR TITLE
Redshift SL refactoring 2

### DIFF
--- a/.changes/unreleased/Changes-20250604-135353.yaml
+++ b/.changes/unreleased/Changes-20250604-135353.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: 'Minor redshift sl credential refactoring. Code review comments solving for PR #451'
+time: 2025-06-04T13:53:53.129735+03:00

--- a/pkg/dbt_cloud/semantic_layer_credential.go
+++ b/pkg/dbt_cloud/semantic_layer_credential.go
@@ -27,11 +27,6 @@ type SemanticLayerCredentialsResponse struct {
 	Data   []SemanticLayerCredentials `json:"data"`
 }
 
-type SemanticLayerCredentialListResponse struct {
-	Status ResponseStatus             `json:"status"`
-	Data   []SemanticLayerCredentials `json:"data"`
-}
-
 type SemanticLayerCredentialResponse struct {
 	Status ResponseStatus           `json:"status"`
 	Data   SemanticLayerCredentials `json:"data"`
@@ -281,9 +276,9 @@ func (c *Client) UpdateSemanticLayerCredential(
 	}
 
 	req, err := http.NewRequest(
-		"PATCH",
+		"POST",
 		fmt.Sprintf(
-			"%s/v3/accounts/%d/semantic-layer-credentials/%d",
+			"%s/v3/accounts/%d/semantic-layer-credentials/%d/",
 			c.HostURL,
 			c.AccountID,
 			credentialId,


### PR DESCRIPTION
There were additional comments on the following PR: https://github.com/dbt-labs/terraform-provider-dbtcloud/pull/451
and we needed another PR to fix those.

- removed unused code
- PATCH api for update sl credentials turned back to POST api (as it was before PR 451)