### PR TITLE
Fix orphaned semantic layer configuration

### DIFF
--- a/.changes/unreleased/Fixes-20250604-114343.yaml
+++ b/.changes/unreleased/Fixes-20250604-114343.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fixes orphaned semantic layer configuration not showing up in project
+time: 2025-06-04T11:43:43.043953356-05:00

--- a/pkg/dbt_cloud/project.go
+++ b/pkg/dbt_cloud/project.go
@@ -20,6 +20,7 @@ type Project struct {
 	AccountID              int     `json:"account_id"`
 	FreshnessJobId         *int    `json:"freshness_job_id"`
 	DocsJobId              *int    `json:"docs_job_id,"`
+	SemanticLayerConfigID  *int64  `json:"semantic_layer_config_id,omitempty"`
 }
 
 type ProjectListResponse struct {


### PR DESCRIPTION
When creating a semantic layer configuration on a project via terraform, the project isn't being update with the configuration ID, causing it to not appear in the UI and presumably being orphaned.  This adds code to fetch the project and update it with the configuration ID so that it appears in the UI.

I determined this was necessary by following the network request that are made in the UI when creating a semantic config.  I noticed that a POST was made to 2 endpoints when creating a semantic layer configuration.  One to create the configuration, and one to update the project with the configuration ID.