### PR TITLE
SIGN-177 Fix for Branch link in IDE redirects to https://github.com/None/tree/main on projects that were created with terraform

### DIFF
--- a/.changes/unreleased/Fixes-20250616-143517.yaml
+++ b/.changes/unreleased/Fixes-20250616-143517.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Add fix for Branch link in IDE redirects to https://github.com/None/tree/main on projects that were created with terraform
+time: 2025-06-16T14:35:17.284117+03:00

--- a/pkg/dbt_cloud/repository.go
+++ b/pkg/dbt_cloud/repository.go
@@ -24,6 +24,8 @@ type Repository struct {
 	DeployKey                             *DeployKey `json:"deploy_key,omitempty"`
 	DeployKeyID                           *int       `json:"deploy_key_id,omitempty"`
 	PullRequestURLTemplate                string     `json:"pull_request_url_template,omitempty"`
+	RemoteBackend                         string     `json:"remote_backend"`
+	FullName                              string     `json:"full_name"`
 }
 
 type DeployKey struct {
@@ -151,6 +153,14 @@ func (c *Client) CreateRepository(
 		// and we also need to provide the credentials id if it was created
 		if repositoryResponse.Data.RepositoryCredentialsID != nil {
 			newRepository.RepositoryCredentialsID = repositoryResponse.Data.RepositoryCredentialsID
+		}
+		
+		if repositoryResponse.Data.RemoteBackend != "" {
+			newRepository.RemoteBackend = repositoryResponse.Data.RemoteBackend
+		}
+
+		if repositoryResponse.Data.FullName != "" {
+			newRepository.FullName = repositoryResponse.Data.FullName
 		}
 
 		updatedRepo, err := c.UpdateRepository(

--- a/pkg/dbt_cloud/repository.go
+++ b/pkg/dbt_cloud/repository.go
@@ -24,8 +24,8 @@ type Repository struct {
 	DeployKey                             *DeployKey `json:"deploy_key,omitempty"`
 	DeployKeyID                           *int       `json:"deploy_key_id,omitempty"`
 	PullRequestURLTemplate                string     `json:"pull_request_url_template,omitempty"`
-	RemoteBackend                         string     `json:"remote_backend"`
-	FullName                              string     `json:"full_name"`
+	RemoteBackend                         *string    `json:"remote_backend,omitempty"`
+	FullName                              *string    `json:"full_name,omitempty"`
 }
 
 type DeployKey struct {
@@ -155,11 +155,11 @@ func (c *Client) CreateRepository(
 			newRepository.RepositoryCredentialsID = repositoryResponse.Data.RepositoryCredentialsID
 		}
 		
-		if repositoryResponse.Data.RemoteBackend != "" {
+		if repositoryResponse.Data.RemoteBackend != nil {
 			newRepository.RemoteBackend = repositoryResponse.Data.RemoteBackend
 		}
 
-		if repositoryResponse.Data.FullName != "" {
+		if repositoryResponse.Data.FullName != nil {
 			newRepository.FullName = repositoryResponse.Data.FullName
 		}
 

--- a/pkg/dbt_cloud/repository_test.go
+++ b/pkg/dbt_cloud/repository_test.go
@@ -19,11 +19,13 @@ func TestCreateRepository_PreservesRemoteBackendAndFullName(t *testing.T) {
 	server := testutil.NewMockRepositoryServer(accountID, projectID, repositoryID)
 	defer server.Close()
 
+	backend := "github"
+	fullName := "test/repo"
 	server.SetCreateResponse(&dbt_cloud.RepositoryResponse{
 		Data: dbt_cloud.Repository{
 			ID:                        testutil.IntPtr(repositoryID),
-			RemoteBackend:             "github",
-			FullName:                  "test/repo",
+			RemoteBackend:             &backend,
+			FullName:                  &fullName,
 			DeployKeyID:               testutil.IntPtr(deployKeyID),
 			RepositoryCredentialsID:   testutil.IntPtr(credentialsID),
 		},
@@ -32,8 +34,8 @@ func TestCreateRepository_PreservesRemoteBackendAndFullName(t *testing.T) {
 	server.SetUpdateResponse(&dbt_cloud.RepositoryResponse{
 		Data: dbt_cloud.Repository{
 			ID:                        testutil.IntPtr(repositoryID),
-			RemoteBackend:             "github",
-			FullName:                  "test/repo",
+			RemoteBackend:             &backend,
+			FullName:                  &fullName,
 			DeployKeyID:               testutil.IntPtr(deployKeyID),
 			RepositoryCredentialsID:   testutil.IntPtr(credentialsID),
 		},
@@ -64,12 +66,12 @@ func TestCreateRepository_PreservesRemoteBackendAndFullName(t *testing.T) {
 		t.Fatal("Expected update request to be made")
 	}
 
-	if updateReq.RemoteBackend != "github" {
-		t.Errorf("Expected update request to have RemoteBackend 'github', got %s", updateReq.RemoteBackend)
+	if updateReq.RemoteBackend == nil || *updateReq.RemoteBackend != backend {
+		t.Errorf("Expected update request to have RemoteBackend '%s', got '%v'", backend, updateReq.RemoteBackend)
 	}
 
-	if updateReq.FullName != "test/repo" {
-		t.Errorf("Expected update request to have FullName 'test/repo', got %s", updateReq.FullName)
+	if updateReq.FullName == nil || *updateReq.FullName != fullName {
+		t.Errorf("Expected update request to have FullName '%s', got '%v'", fullName, updateReq.FullName)
 	}
 
 	if *updateReq.DeployKeyID != deployKeyID {

--- a/pkg/dbt_cloud/repository_test.go
+++ b/pkg/dbt_cloud/repository_test.go
@@ -1,0 +1,82 @@
+package dbt_cloud_test
+
+import (
+	"testing"
+
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud/testutil"
+)
+
+func TestCreateRepository_PreservesRemoteBackendAndFullName(t *testing.T) {
+	const (
+		accountID = 123
+		projectID = 456
+		repositoryID = 789
+		deployKeyID = 101
+		credentialsID = 202
+	)
+
+	server := testutil.NewMockRepositoryServer(accountID, projectID, repositoryID)
+	defer server.Close()
+
+	server.SetCreateResponse(&dbt_cloud.RepositoryResponse{
+		Data: dbt_cloud.Repository{
+			ID:                        testutil.IntPtr(repositoryID),
+			RemoteBackend:             "github",
+			FullName:                  "test/repo",
+			DeployKeyID:               testutil.IntPtr(deployKeyID),
+			RepositoryCredentialsID:   testutil.IntPtr(credentialsID),
+		},
+	})
+
+	server.SetUpdateResponse(&dbt_cloud.RepositoryResponse{
+		Data: dbt_cloud.Repository{
+			ID:                        testutil.IntPtr(repositoryID),
+			RemoteBackend:             "github",
+			FullName:                  "test/repo",
+			DeployKeyID:               testutil.IntPtr(deployKeyID),
+			RepositoryCredentialsID:   testutil.IntPtr(credentialsID),
+		},
+	})
+
+	client := testutil.CreateTestClient(server.URL(), accountID)
+
+	_, err := client.CreateRepository(
+		projectID,
+		"git@github.com:test/repo.git",
+		true,
+		"github_app",
+		0,
+		0,
+		"",
+		"",
+		false,
+		"https://github.com/test/repo/compare/{{destination}}...{{source}}",
+	)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	updateReq := server.GetLastUpdateRequest()
+
+	if updateReq == nil {
+		t.Fatal("Expected update request to be made")
+	}
+
+	if updateReq.RemoteBackend != "github" {
+		t.Errorf("Expected update request to have RemoteBackend 'github', got %s", updateReq.RemoteBackend)
+	}
+
+	if updateReq.FullName != "test/repo" {
+		t.Errorf("Expected update request to have FullName 'test/repo', got %s", updateReq.FullName)
+	}
+
+	if *updateReq.DeployKeyID != deployKeyID {
+		t.Errorf("Expected update request to have DeployKeyID %d, got %d", deployKeyID, *updateReq.DeployKeyID)
+	}
+
+	if *updateReq.RepositoryCredentialsID != credentialsID {
+		t.Errorf("Expected update request to have RepositoryCredentialsID %d, got %d", credentialsID, *updateReq.RepositoryCredentialsID)
+	}
+}

--- a/pkg/dbt_cloud/testutil/repository_test_helpers.go
+++ b/pkg/dbt_cloud/testutil/repository_test_helpers.go
@@ -1,0 +1,98 @@
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+)
+
+type MockRepositoryServer struct {
+	server *httptest.Server
+	createResponse *dbt_cloud.RepositoryResponse
+	updateResponse *dbt_cloud.RepositoryResponse
+	accountID int
+	projectID int
+	repositoryID int
+	lastUpdateRequest *dbt_cloud.Repository
+}
+
+func (m *MockRepositoryServer) handleRequest(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	createPath := fmt.Sprintf("/v3/accounts/%d/projects/%d/repositories/", m.accountID, m.projectID)
+	updatePath := fmt.Sprintf("/v3/accounts/%d/projects/%d/repositories/%d/", m.accountID, m.projectID, m.repositoryID)
+
+	if r.Method == "POST" && r.URL.Path == createPath {
+		if m.createResponse != nil {
+			json.NewEncoder(w).Encode(m.createResponse)
+			return
+		}
+	}
+
+	if r.Method == "POST" && r.URL.Path == updatePath {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var updateReq dbt_cloud.Repository
+		if err := json.Unmarshal(body, &updateReq); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		m.lastUpdateRequest = &updateReq
+
+		if m.updateResponse != nil {
+			json.NewEncoder(w).Encode(m.updateResponse)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func (m *MockRepositoryServer) GetLastUpdateRequest() *dbt_cloud.Repository {
+	return m.lastUpdateRequest
+}
+
+func NewMockRepositoryServer(accountID, projectID, repositoryID int) *MockRepositoryServer {
+	mock := &MockRepositoryServer{
+		accountID: accountID,
+		projectID: projectID,
+		repositoryID: repositoryID,
+	}
+	mock.server = httptest.NewServer(http.HandlerFunc(mock.handleRequest))
+	return mock
+}
+
+func (m *MockRepositoryServer) SetCreateResponse(response *dbt_cloud.RepositoryResponse) {
+	m.createResponse = response
+}
+
+func (m *MockRepositoryServer) SetUpdateResponse(response *dbt_cloud.RepositoryResponse) {
+	m.updateResponse = response
+}
+
+func (m *MockRepositoryServer) Close() {
+	m.server.Close()
+}
+
+func (m *MockRepositoryServer) URL() string {
+	return m.server.URL
+}
+
+func CreateTestClient(serverURL string, accountID int) *dbt_cloud.Client {
+	return &dbt_cloud.Client{
+		HostURL:    serverURL,
+		HTTPClient: &http.Client{},
+		AccountID:  accountID,
+	}
+}
+
+func IntPtr(i int) *int {
+	return &i
+} 

--- a/pkg/framework/objects/azure_dev_ops_repository/data_source.go
+++ b/pkg/framework/objects/azure_dev_ops_repository/data_source.go
@@ -41,9 +41,18 @@ func (d *azureDevOpsRepositoryDataSource) Read(
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("failed to get Azure Dev Ops repository %s in project %s", repositoryName, azureDevOpsProjectID),
+			fmt.Sprintf("Failed to get Azure Dev Ops repository %s in project %s", repositoryName, azureDevOpsProjectID),
 			err.Error(),
 		)
+		return
+	}
+
+	if azureDevOpsRepository == nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Azure Dev Ops repository %s in project %s not found", repositoryName, azureDevOpsProjectID),
+			"The repository was not returned by the API.",
+		)
+		return
 	}
 
 	state.ID = types.StringValue(azureDevOpsRepository.ID)

--- a/pkg/framework/objects/project_repository/schema.go
+++ b/pkg/framework/objects/project_repository/schema.go
@@ -18,9 +18,6 @@ func Schema() schema.Schema {
 			"repository_id": schema.Int64Attribute{
 				Description: "Repository ID",
 				Required:    true,
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 			},
 			"project_id": schema.Int64Attribute{
 				Description: "Project ID",


### PR DESCRIPTION
- Added `RemoteBackend` and `FullName` when creating/ updating `dbtcloud_repository`
- Added test at `dbt_cloud` client level to cover this case and see that the update request is sent accordingly
- Added fix to the repository update method that wasn't updating all the fields accordingly
- Removed `RequiresReplace()` for the `repository_id` field in the `dbtcloud_project_repositoryso` so that the whole resource doesn't get recreated for just updating the `pull_request_url_template` for example. (If a field from the `dbtcloud_repository` with `RequiresReplace()` will change, the `dbtcloud_project_repository` will change as well)


- [x] Manual testing
- [x] Added tests