### PR TITLE
SIGN-200 Fixed Missing Required Attribute Issue

### DIFF
--- a/.changes/unreleased/Fixes-20250620-120720.yaml
+++ b/.changes/unreleased/Fixes-20250620-120720.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fixed Missing Required Attribute Issue Caused by SemanticLayerCredentialValidator
+time: 2025-06-20T12:07:20.717058+03:00

--- a/pkg/framework/objects/semantic_layer_credential/databricks_sl_credential_resource_acceptance_test.go
+++ b/pkg/framework/objects/semantic_layer_credential/databricks_sl_credential_resource_acceptance_test.go
@@ -27,8 +27,6 @@ func TestAccDbtCloudDatabricksSemanticLayerConfigurationResource(t *testing.T) {
 	catalog2 := ""
 	token := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	token2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	adapterType := "databricks"
-	schema := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
@@ -42,8 +40,6 @@ func TestAccDbtCloudDatabricksSemanticLayerConfigurationResource(t *testing.T) {
 					adapterVersion,
 					catalog,
 					token,
-					adapterType,
-					schema,
 				),
 
 				Check: resource.ComposeTestCheckFunc(
@@ -67,16 +63,6 @@ func TestAccDbtCloudDatabricksSemanticLayerConfigurationResource(t *testing.T) {
 						"credential.token",
 						token,
 					),
-					resource.TestCheckResourceAttr(
-						"dbtcloud_databricks_semantic_layer_credential.test",
-						"credential.adapter_type",
-						adapterType,
-					),
-					resource.TestCheckResourceAttr(
-						"dbtcloud_databricks_semantic_layer_credential.test",
-						"credential.schema",
-						schema,
-					),
 				),
 			},
 			// MODIFY general config fields
@@ -87,8 +73,6 @@ func TestAccDbtCloudDatabricksSemanticLayerConfigurationResource(t *testing.T) {
 					adapterVersion,
 					catalog2,
 					token2,
-					adapterType,
-					schema,
 				),
 
 				Check: resource.ComposeTestCheckFunc(
@@ -119,8 +103,6 @@ func testAccDbtCloudDatabricksSemanticLayerCredentialResource(
 	adapterVersion string,
 	catalog string,
 	token string,
-	adapterType string,
-	schema string,
 ) string {
 
 	return fmt.Sprintf(`
@@ -135,10 +117,9 @@ credential = {
   	project_id = "%s"
     catalog = "%s"
     token = "%s"
-    adapter_type = "%s"
-    schema = "%s"
+	semantic_layer_credential = true
   }
-}`, strconv.Itoa(projectID), name, adapterVersion, strconv.Itoa(projectID), catalog, token, adapterType, schema)
+}`, strconv.Itoa(projectID), name, adapterVersion, strconv.Itoa(projectID), catalog, token)
 }
 
 func testAccCheckDbtCloudDatabricksSemanticLayerCredentialDestroy(s *terraform.State) error {

--- a/pkg/helper/sl_cred_validator.go
+++ b/pkg/helper/sl_cred_validator.go
@@ -21,6 +21,11 @@ func (v SemanticLayerCredentialValidator) MarkdownDescription(ctx context.Contex
 }
 
 func (v SemanticLayerCredentialValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
 	var semantic_layer_enabled types.Bool
 	semanticLayerPath := req.Path.ParentPath().AtName("semantic_layer_credential")
 	diags := req.Config.GetAttribute(ctx, semanticLayerPath, &semantic_layer_enabled)
@@ -30,7 +35,7 @@ func (v SemanticLayerCredentialValidator) ValidateString(ctx context.Context, re
 	}
 
 	if semantic_layer_enabled.IsNull() || !semantic_layer_enabled.ValueBool() {
-		if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() == "" {
+		if req.ConfigValue.IsNull() || req.ConfigValue.ValueString() == "" {
 			resp.Diagnostics.AddAttributeError(
 				req.Path,
 				"Missing Required Attribute",


### PR DESCRIPTION
Customer received error message '`schema` must be provided when `semantic_layer_credential` is false.' even if they provided the value in .tfvars file

SemanticLayerCredentialValidator which was added on some fields was throwing error before reading the values assigned from .tfvars file.