### PR TITLE
#485 Allow empty project subdirectory

### DIFF
--- a/.changes/unreleased/Fixes-20250715-151215.yaml
+++ b/.changes/unreleased/Fixes-20250715-151215.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Allow empty string as Project subdirectory
+time: 2025-07-15T15:12:15.089741+03:00

--- a/pkg/framework/objects/project/resource.go
+++ b/pkg/framework/objects/project/resource.go
@@ -97,8 +97,6 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 
 	if project.DbtProjectSubdirectory != nil {
 		plan.DbtProjectSubdirectory = types.StringValue(*project.DbtProjectSubdirectory)
-	} else {
-		plan.DbtProjectSubdirectory = types.StringNull()
 	}
 
 	plan.DbtProjectType = types.Int64Value(project.DbtProjectType)
@@ -145,8 +143,6 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	if project.DbtProjectSubdirectory != nil {
 		state.DbtProjectSubdirectory = types.StringValue(*project.DbtProjectSubdirectory)
-	} else {
-		state.DbtProjectSubdirectory = types.StringNull()
 	}
 
 	state.DbtProjectType = types.Int64Value(project.DbtProjectType)
@@ -207,7 +203,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		dbtProjectSubdir := plan.DbtProjectSubdirectory.ValueString()
 		updateProject.DbtProjectSubdirectory = &dbtProjectSubdir
 	}
-	
+
 	if !plan.DbtProjectType.IsNull() {
 		dbtProjectType := plan.DbtProjectType.ValueInt64()
 		updateProject.DbtProjectType = dbtProjectType
@@ -234,8 +230,6 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	if project.DbtProjectSubdirectory != nil {
 		plan.DbtProjectSubdirectory = types.StringValue(*project.DbtProjectSubdirectory)
-	} else {
-		plan.DbtProjectSubdirectory = types.StringNull()
 	}
 
 	plan.DbtProjectType = types.Int64Value(project.DbtProjectType)

--- a/pkg/framework/objects/project/resource_acceptance_test.go
+++ b/pkg/framework/objects/project/resource_acceptance_test.go
@@ -60,6 +60,28 @@ var modifyStep = resource.TestStep{
 	),
 }
 
+var emptyStringStep = resource.TestStep{
+	Config: testAccDbtCloudProjectResourceEmptyStringConfig(projectName, projectDescription),
+	Check: resource.ComposeTestCheckFunc(
+		testAccCheckDbtCloudProjectExists("dbtcloud_project.test_project"),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_project.test_project",
+			"name",
+			projectName,
+		),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_project.test_project",
+			"dbt_project_subdirectory",
+			"",
+		),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_project.test_project",
+			"type",
+			"0",
+		),
+	),
+}
+
 func TestAccDbtCloudProjectResource(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -70,6 +92,7 @@ func TestAccDbtCloudProjectResource(t *testing.T) {
 			createStep,
 			renameStep,
 			modifyStep,
+			emptyStringStep,
 			{
 				ResourceName:            "dbtcloud_project.test_project",
 				ImportState:             true,
@@ -97,6 +120,20 @@ resource "dbtcloud_project" "test_project" {
   name = "%s"
   description = "%s"
   dbt_project_subdirectory = "/project/subdirectory_where/dbt-is"
+  type = 0
+}
+`, projectName, projectDescription)
+}
+
+func testAccDbtCloudProjectResourceEmptyStringConfig(
+	projectName string,
+	projectDescription string,
+) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_project" "test_project" {
+  name = "%s"
+  description = "%s"
+  dbt_project_subdirectory = ""
   type = 0
 }
 `, projectName, projectDescription)

--- a/pkg/framework/objects/project/schema.go
+++ b/pkg/framework/objects/project/schema.go
@@ -5,6 +5,7 @@ import (
 	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
@@ -208,6 +209,7 @@ var resourceSchema = resource_schema.Schema{
 			Description: "DBT project subdirectory",
 			Optional:    true,
 			Computed:    true,
+			Default:     stringdefault.StaticString(""),
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},


### PR DESCRIPTION
These changes allow users to now provision projects from Terraform with an empty string as a project subdirectory.

An integration test was added for this specific scenario.