### PR TITLE
Add compatible and extended as supported environment versions

### DIFF
--- a/.changes/unreleased/Changes-20250715-175930.yaml
+++ b/.changes/unreleased/Changes-20250715-175930.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: Allow compatible and extended as dbt_version on Environment resources
+time: 2025-07-15T17:59:30.073368+03:00

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -14,7 +14,7 @@ Resource to manage dbt Cloud environments for the different dbt Cloud projects. 
 
 ```terraform
 resource "dbtcloud_environment" "ci_environment" {
-  // the dbt_version is major.minor.0-latest , major.minor.0-pre, latest or latest-fusion (by default, it is set to latest if not configured)
+  // the dbt_version is major.minor.0-latest , major.minor.0-pre, compatible, extended, versionless, latest or latest-fusion (by default, it is set to latest if not configured)
   dbt_version   = "latest-fusion"
   name          = "CI"
   project_id    = dbtcloud_project.dbt_project.id
@@ -58,7 +58,7 @@ resource "dbtcloud_environment" "dev_environment" {
 - `connection_id` (Number) A connection ID (used with Global Connections)
 - `credential_id` (Number) The project ID to which the environment belongs.
 - `custom_branch` (String) The custom branch name to use
-- `dbt_version` (String) Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `versionless`, `latest` or `latest-fusion`. While `versionless` is still supported, using `latest` or `latest-fusion` is recommended. Defaults to `latest` if no version is provided
+- `dbt_version` (String) Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `compatible`, `extended`, `versionless`, `latest` or `latest-fusion`. While `versionless` is still supported, using `latest` or `latest-fusion` is recommended. Defaults to `latest` if no version is provided
 - `deployment_type` (String) The type of environment. Only valid for environments of type 'deployment' and for now can only be 'production', 'staging' or left empty for generic environments
 - `enable_model_query_history` (Boolean) Whether to enable model query history in this environment. As of Oct 2024, works only for Snowflake and BigQuery.
 - `extended_attributes_id` (Number) The ID of the extended attributes applied

--- a/examples/resources/dbtcloud_environment/resource.tf
+++ b/examples/resources/dbtcloud_environment/resource.tf
@@ -1,5 +1,5 @@
 resource "dbtcloud_environment" "ci_environment" {
-  // the dbt_version is major.minor.0-latest , major.minor.0-pre, latest or latest-fusion (by default, it is set to latest if not configured)
+  // the dbt_version is major.minor.0-latest , major.minor.0-pre, compatible, extended, versionless, latest or latest-fusion (by default, it is set to latest if not configured)
   dbt_version   = "latest-fusion"
   name          = "CI"
   project_id    = dbtcloud_project.dbt_project.id

--- a/pkg/framework/objects/environment/schema.go
+++ b/pkg/framework/objects/environment/schema.go
@@ -206,7 +206,7 @@ func (r *environmentResource) Schema(
 				Computed:    true,
 				Optional:    true,
 				Default:     stringdefault.StaticString("latest"),
-				Description: "Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `versionless`, `latest` or `latest-fusion`. While `versionless` is still supported, using `latest` or `latest-fusion` is recommended. Defaults to `latest` if no version is provided",
+				Description: "Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `compatible`, `extended`, `versionless`, `latest` or `latest-fusion`. While `versionless` is still supported, using `latest` or `latest-fusion` is recommended. Defaults to `latest` if no version is provided",
 				Validators: []validator.String{
 					helper.DbtVersionValidator{}, // Custom validator to check the dbt version format
 				},

--- a/pkg/helper/dbt_version_validator.go
+++ b/pkg/helper/dbt_version_validator.go
@@ -11,11 +11,11 @@ import (
 type DbtVersionValidator struct{}
 
 func (v DbtVersionValidator) Description(ctx context.Context) string {
-	return "Validates that the dbt_version is in the format `major.minor.0-latest`, `major.minor.0-pre`, `versionless`, `latest`, or `latest-fusion`."
+	return "Validates that the dbt_version is in the format `major.minor.0-latest`, `major.minor.0-pre`, `compatible`, `extended`, `versionless`, `latest`, or `latest-fusion`."
 }
 
 func (v DbtVersionValidator) MarkdownDescription(ctx context.Context) string {
-	return "Validates that the `dbt_version` is in the format `major.minor.0-latest`, `major.minor.0-pre`, `versionless`, `latest` or `latest-fusion`."
+	return "Validates that the `dbt_version` is in the format `major.minor.0-latest`, `major.minor.0-pre`, `compatible`, `extended`, `versionless`, `latest` or `latest-fusion`."
 }
 
 func (v DbtVersionValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
@@ -28,7 +28,7 @@ func (v DbtVersionValidator) ValidateString(ctx context.Context, req validator.S
 	dbtVersion := req.ConfigValue.ValueString()
 
 	// Define the regex pattern for valid dbt_version formats
-	validVersionPattern := `^(latest|versionless|latest-fusion|[0-9]+\.[0-9]+\.0-(latest|pre))$`
+	validVersionPattern := `^(compatible|extended|latest|versionless|latest-fusion|[0-9]+\.[0-9]+\.0-(latest|pre))$`
 	matched, err := regexp.MatchString(validVersionPattern, dbtVersion)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -42,7 +42,7 @@ func (v DbtVersionValidator) ValidateString(ctx context.Context, req validator.S
 	if !matched {
 		resp.Diagnostics.AddError(
 			"Invalid dbt_version Format",
-			fmt.Sprintf("The `dbt_version` must be in the format `major.minor.0-latest`, `major.minor.0-pre`, `versionless`, `latest` or `latest-fusion`. Got: %s", dbtVersion),
+			fmt.Sprintf("The `dbt_version` must be in the format `major.minor.0-latest`, `major.minor.0-pre`, `compatible`, `extended`, `versionless`, `latest` or `latest-fusion`. Got: %s", dbtVersion),
 		)
 	}
 }


### PR DESCRIPTION
Resolves #492 

These changes allow users to set environments up with `compatible` and `extended` as versions.