### PR TITLE
Removed omitempty from the bool property Active, as this creates an u…

### DIFF
--- a/.changes/unreleased/Fixes-20250717-172434.yaml
+++ b/.changes/unreleased/Fixes-20250717-172434.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Removed omitempty from the bool property Active, as this creates an unexpected behavior when json marshalling is done. False values are seen as 0
+time: 2025-07-17T17:24:34.00815+03:00

--- a/pkg/dbt_cloud/webhook.go
+++ b/pkg/dbt_cloud/webhook.go
@@ -33,7 +33,7 @@ type WebhookWrite struct {
 	ClientUrl   string   `json:"client_url"`
 	EventTypes  []string `json:"event_types,omitempty"`
 	JobIds      []int64  `json:"job_ids"`
-	Active      bool     `json:"active,omitempty"`
+	Active      bool     `json:"active"`
 }
 
 func (c *Client) GetWebhook(webhookID string) (*WebhookRead, error) {

--- a/pkg/framework/objects/webhook/resource_acceptance_test.go
+++ b/pkg/framework/objects/webhook/resource_acceptance_test.go
@@ -15,6 +15,7 @@ import (
 var webhookName = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 var webhookName2 = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 var projectName = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+var active = "false"
 
 var basicConfigTestStep = resource.TestStep{
 	Config: testAccDbtCloudWebhookResourceBasicConfig(webhookName, projectName),
@@ -52,7 +53,7 @@ var basicConfigTestStep = resource.TestStep{
 }
 
 var modifyConfigTestStep = resource.TestStep{
-	Config: testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName),
+	Config: testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, active),
 	Check: resource.ComposeTestCheckFunc(
 		testAccCheckDbtCloudWebhookExists("dbtcloud_webhook.test_webhook"),
 		resource.TestCheckResourceAttr(
@@ -82,6 +83,11 @@ var modifyConfigTestStep = resource.TestStep{
 			"dbtcloud_webhook.test_webhook",
 			"client_url",
 			"https://example.com/test",
+		),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_webhook.test_webhook",
+			"active",
+			active,
 		),
 	),
 }
@@ -131,7 +137,7 @@ resource "dbtcloud_webhook" "test_webhook" {
 `, projectName, webhookName)
 }
 
-func testAccDbtCloudWebhookResourceFullConfig(webhookName, projectName string) string {
+func testAccDbtCloudWebhookResourceFullConfig(webhookName, projectName, active string) string {
 	return fmt.Sprintf(`
 resource "dbtcloud_project" "test_project" {
   name        = "%s"
@@ -168,8 +174,9 @@ resource "dbtcloud_webhook" "test_webhook" {
 	  "job.run.completed"
 	]
 	job_ids = [dbtcloud_job.test.id]
+	active = "%s"
   }
-`, projectName, acctest_config.DBT_CLOUD_VERSION, webhookName)
+`, projectName, acctest_config.DBT_CLOUD_VERSION, webhookName, active)
 }
 
 func testAccCheckDbtCloudWebhookExists(resource string) resource.TestCheckFunc {


### PR DESCRIPTION
In the provider, we declared the webhook struct like this:
```
type WebhookWrite struct {
    WebhookId   string   `json:"id"`
    Name        string   `json:"name"`
    Description string   `json:"description,omitempty"`
    ClientUrl   string   `json:"client_url"`
    EventTypes  []string `json:"event_types,omitempty"`
    JobIds      []int64  `json:"job_ids"`
    Active      bool     `json:"active,omitempty"`
}
```
The omitempty is inducing an unexpected behavior when we're parsing the Active property when it's false, because false translates to a 0 and the omitempty party is telling the json marshaller to ignore it. So the object we're sending to dbt cloud does not contain the Active property at all.
I'll fix this today and we'll release an update early next week, I want to check any other places we might do the same thing. Thank you for raising it!