### PR TITLE
Update environment.md - docs for credential_id

### DIFF
--- a/.changes/unreleased/Documentation-20250804-104556.yaml
+++ b/.changes/unreleased/Documentation-20250804-104556.yaml
@@ -1,0 +1,3 @@
+kind: Documentation
+body: Doc updates
+time: 2025-08-04T10:45:56.790732+03:00

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -56,7 +56,7 @@ resource "dbtcloud_environment" "dev_environment" {
 ### Optional
 
 - `connection_id` (Number) A connection ID (used with Global Connections)
-- `credential_id` (Number) The project ID to which the environment belongs.
+- `credential_id` (Number) The id of the associated credentials. Null for development environments.
 - `custom_branch` (String) The custom branch name to use
 - `dbt_version` (String) Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `compatible`, `extended`, `versionless`, `latest` or `latest-fusion`. While `versionless` is still supported, using `latest` or `latest-fusion` is recommended. Defaults to `latest` if no version is provided
 - `deployment_type` (String) The type of environment. Only valid for environments of type 'deployment' and for now can only be 'production', 'staging' or left empty for generic environments

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -56,7 +56,7 @@ resource "dbtcloud_environment" "dev_environment" {
 ### Optional
 
 - `connection_id` (Number) A connection ID (used with Global Connections)
-- `credential_id` (Number) The id of the associated credentials. Null for development environments.
+- `credential_id` (Number) The project ID to which the environment belongs.
 - `custom_branch` (String) The custom branch name to use
 - `dbt_version` (String) Version number of dbt to use in this environment. It needs to be in the format `major.minor.0-latest` (e.g. `1.5.0-latest`), `major.minor.0-pre`, `compatible`, `extended`, `versionless`, `latest` or `latest-fusion`. While `versionless` is still supported, using `latest` or `latest-fusion` is recommended. Defaults to `latest` if no version is provided
 - `deployment_type` (String) The type of environment. Only valid for environments of type 'deployment' and for now can only be 'production', 'staging' or left empty for generic environments


### PR DESCRIPTION
The `credential_id` had documentation for `project_id`. Fixed that.

But, I am curious about something...

Here it says `credential_id`, but [via the api](https://docs.getdbt.com/dbt-cloud/api-v3#/operations/Retrieve%20Environment), it is `credentials_id`. 
I see both are used throughout the codebase. Which is correct?

https://github.com/search?q=repo%3Adbt-labs%2Fterraform-provider-dbtcloud+credential_id&type=code 
vs.
https://github.com/search?q=repo%3Adbt-labs%2Fterraform-provider-dbtcloud+credentials_id&type=code

