### PR TITLE
fix: resolve integer overflow for large account IDs

### DIFF
--- a/pkg/dbt_cloud/client.go
+++ b/pkg/dbt_cloud/client.go
@@ -17,7 +17,7 @@ type Client struct {
 	HTTPClient           *http.Client
 	Token                string
 	AccountURL           string
-	AccountID            int
+	AccountID            int64
 	RetryIntervalSeconds int
 	MaxRetries           int
 	RetriableStatusCodes []string
@@ -47,36 +47,36 @@ type ResponseExtra struct {
 }
 
 type AuthResponseData struct {
-	DocsJobId                      int    `json:"docs_job_id"`
-	FreshnessJobId                 int    `json:"freshness_job_id"`
-	LockReason                     string `json:"lock_reason"`
-	UnlockIfSubscriptionRenewed    bool   `json:"unlock_if_subscription_renewed"`
-	ReadOnlySeats                  int    `json:"read_only_seats"`
-	Id                             int    `json:"id"`
-	Name                           string `json:"name"`
-	State                          int    `json:"state"`
-	Plan                           string `json:"plan"`
-	PendingCancel                  bool   `json:"pending_cancel"`
-	RunSlots                       int    `json:"run_slots"`
-	DeveloperSeats                 int    `json:"developer_seats"`
-	QueueLimit                     int    `json:"queue_limit"`
-	PodMemoryRequestMebibytes      int    `json:"pod_memory_request_mebibytes"`
-	RunDurationLimitSeconds        int    `json:"run_duration_limit_seconds"`
-	EnterpriseAuthenticationMethod string `json:"enterprise_authentication_method"`
-	EnterpriseLoginSlug            string `json:"enterprise_login_slug"`
-	EnterpriseUniqueIdentifier     string `json:"enterprise_unique_identifier"`
-	BillingEmailAddress            string `json:"billing_email_address"`
-	Locked                         bool   `json:"locked"`
-	DevelopFileSystem              bool   `json:"develop_file_system"`
-	UnlockedAt                     string `json:"unlocked_at"`
-	CreatedAt                      string `json:"created_at"`
-	UpdatedAt                      string `json:"updated_at"`
-	StarterRepoUrl                 string `json:"starter_repo_url"`
-	SsoReauth                      bool   `json:"sso_reauth"`
-	GitAuthLevel                   string `json:"git_auth_level"`
-	DocsJob                        string `json:"docs_job"`
-	FreshnessJob                   string `json:"freshness_job"`
-	EnterpriseLoginUrl             string `json:"enterprise_login_url"`
+	DocsJobId                      int64   `json:"docs_job_id"`
+	FreshnessJobId                 int64   `json:"freshness_job_id"`
+	LockReason                     string  `json:"lock_reason"`
+	UnlockIfSubscriptionRenewed    bool    `json:"unlock_if_subscription_renewed"`
+	ReadOnlySeats                  int64   `json:"read_only_seats"`
+	Id                             int64   `json:"id"`
+	Name                           string  `json:"name"`
+	State                          int64   `json:"state"`
+	Plan                           string  `json:"plan"`
+	PendingCancel                  bool    `json:"pending_cancel"`
+	RunSlots                       int64   `json:"run_slots"`
+	DeveloperSeats                 int64   `json:"developer_seats"`
+	QueueLimit                     int64   `json:"queue_limit"`
+	PodMemoryRequestMebibytes      int64   `json:"pod_memory_request_mebibytes"`
+	RunDurationLimitSeconds        int64   `json:"run_duration_limit_seconds"`
+	EnterpriseAuthenticationMethod string  `json:"enterprise_authentication_method"`
+	EnterpriseLoginSlug            string  `json:"enterprise_login_slug"`
+	EnterpriseUniqueIdentifier     string  `json:"enterprise_unique_identifier"`
+	BillingEmailAddress            string  `json:"billing_email_address"`
+	Locked                         bool    `json:"locked"`
+	DevelopFileSystem              bool    `json:"develop_file_system"`
+	UnlockedAt                     string  `json:"unlocked_at"`
+	CreatedAt                      string  `json:"created_at"`
+	UpdatedAt                      string  `json:"updated_at"`
+	StarterRepoUrl                 string  `json:"starter_repo_url"`
+	SsoReauth                      bool    `json:"sso_reauth"`
+	GitAuthLevel                   string  `json:"git_auth_level"`
+	DocsJob                        string  `json:"docs_job"`
+	FreshnessJob                   string  `json:"freshness_job"`
+	EnterpriseLoginUrl             string  `json:"enterprise_login_url"`
 }
 
 // AuthResponse -
@@ -97,7 +97,7 @@ type APIError struct {
 }
 
 // NewClient -
-func NewClient(account_id *int, token *string, host_url *string, maxRetries *int, retryIntervalSeconds *int, retriableStatusCodes []string) (*Client, error) {
+func NewClient(account_id *int64, token *string, host_url *string, maxRetries *int, retryIntervalSeconds *int, retriableStatusCodes []string) (*Client, error) {
 
 	if (token == nil) || (*token == "") {
 		return nil, fmt.Errorf("token is set but it is empty")

--- a/pkg/provider/framework_provider.go
+++ b/pkg/provider/framework_provider.go
@@ -185,12 +185,12 @@ func (p *dbtCloudProvider) Configure(
 	}
 
 	accountIDString := os.Getenv("DBT_CLOUD_ACCOUNT_ID")
-	accountID, _ := strconv.Atoi(accountIDString)
+	accountID, _ := strconv.ParseInt(accountIDString, 10, 64)
 	token := os.Getenv("DBT_CLOUD_TOKEN")
 	hostURL := os.Getenv("DBT_CLOUD_HOST_URL")
 
 	if !config.AccountID.IsNull() {
-		accountID = int(config.AccountID.ValueInt64())
+		accountID = config.AccountID.ValueInt64()
 	}
 
 	if !config.Token.IsNull() {


### PR DESCRIPTION
## 🐛 **Issue**
The dbt Cloud Terraform provider fails with large account IDs due to integer overflow when using 32-bit compilation targets.

**Error:**
Error: json: cannot unmarshal number 704718xxxxxxxxxxx  into Go struct field AuthResponseData.data.id of type int

### Technical Analysis
The issue occurs because:
1. The account ID `70471823482680` is too large for a 32-bit integer
2. The provider is trying to unmarshal the JSON response into an `int` type
3. The number gets converted to scientific notation `7.047182348268e+13`
4. The provider expects a whole number but receives a float


## 🔍 **Root Cause**
- Account ID `70471823482680` exceeds 32-bit int limit (2,147,483,647)
- Provider compiled for multiple architectures including 32-bit (386)
- Go's `int` type becomes 32-bit on 32-bit compilation targets
- JSON unmarshaling fails when large numbers exceed 32-bit limit

## 🛠️ **Solution**
Change all ID fields from `int` to `int64` to support large account IDs across all compilation targets.

## �� **Changes Made**
1. **pkg/dbt_cloud/client.go line 20:** `AccountID int` → `AccountID int64`
2. **pkg/dbt_cloud/client.go lines 50-79:** All `int` fields in `AuthResponseData` struct → `int64`
3. **pkg/dbt_cloud/client.go line 99:** Function signature `*int` → `*int64`
4. **pkg/provider/framework_provider.go line 185:** `strconv.Atoi` → `strconv.ParseInt(accountIDString, 10, 64)`
5. **pkg/provider/framework_provider.go line 189:** Remove unnecessary `int()` cast

## ✅ **Testing**
- Tested with account ID: `70471823482680`
- Verified JSON unmarshaling works with large numbers
- Confirmed backward compatibility with smaller account IDs

## �� **Impact**
- Fixes issue for users with large account IDs 
- Maintains backward compatibility
- Architecture-independent solution
- Common in enterprise environments

### Suggested Solutions
1. **Update the data type**: Change from `int` to `int64` or `string` for account_id fields
2. **Add validation**: Handle large numbers gracefully
3. **Document workarounds**: Provide guidance for users with large account IDs


### Related Issues
- Similar issue reported in Pulumi Terraform Bridge: https://github.com/pulumi/pulumi-terraform-bridge/issues/1940
- This appears to be a common problem with large numeric IDs in Terraform providers