### PR TITLE
Add skip_credentials_validation flag to provider

### DIFF
--- a/.changes/unreleased/Changes-20251111-171704.yaml
+++ b/.changes/unreleased/Changes-20251111-171704.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: Added skip_credentials_validation flag to provider for skipping credential validation during initialization
+time: 2025-11-11T17:17:04.65679+02:00

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,4 +43,5 @@ provider "dbtcloud" {
 - `max_retries` (Number) The maximum number of retries to attempt for requests that fail due to rate limiting. Defaults to 3 retries.
 - `retriable_status_codes` (List of String) List of HTTP status codes that should be retried when encountered. Defaults to [429, 500, 502, 503, 504].
 - `retry_interval_seconds` (Number) The number of seconds to wait before retrying a request that failed due to rate limiting. Defaults to 10 seconds.
+- `skip_credentials_validation` (Boolean) If set to true, the provider will not validate credentials during initialization. This can be useful for testing and for dbt Cloud API implementations that do not have standard authentication available. Defaults to false.
 - `token` (String, Sensitive) API token for your dbt Cloud. Instead of setting the parameter, you can set the environment variable `DBT_CLOUD_TOKEN`

--- a/pkg/dbt_cloud/client.go
+++ b/pkg/dbt_cloud/client.go
@@ -115,7 +115,7 @@ type APIError struct {
 }
 
 // NewClient -
-func NewClient(account_id *int, token *string, host_url *string, maxRetries *int, retryIntervalSeconds *int, retriableStatusCodes []string) (*Client, error) {
+func NewClient(account_id *int, token *string, host_url *string, maxRetries *int, retryIntervalSeconds *int, retriableStatusCodes []string, skipCredentialsValidation bool) (*Client, error) {
 
 	if (token == nil) || (*token == "") {
 		return nil, fmt.Errorf("token is set but it is empty")
@@ -138,7 +138,7 @@ func NewClient(account_id *int, token *string, host_url *string, maxRetries *int
 	}
 
 	_, runningAcceptanceTests := os.LookupEnv("TF_ACC")
-	if !runningAcceptanceTests {
+	if !runningAcceptanceTests && !skipCredentialsValidation {
 		url := c.BuildV2URL(ResourceAccounts)
 
 		// authenticate

--- a/pkg/provider/framework_provider.go
+++ b/pkg/provider/framework_provider.go
@@ -116,6 +116,10 @@ func (p *dbtCloudProvider) Schema(
 				Optional:    true,
 				Description: "If set to true, the provider will not retry requests that fail due to rate limiting. Defaults to false.",
 			},
+			"skip_credentials_validation": schema.BoolAttribute{
+				Optional:    true,
+				Description: "If set to true, the provider will not validate credentials during initialization. This can be useful for testing and for dbt Cloud API implementations that do not have standard authentication available. Defaults to false.",
+			},
 			"retriable_status_codes": schema.ListAttribute{
 				Optional:    true,
 				ElementType: types.StringType,
@@ -134,13 +138,14 @@ func (p *dbtCloudProvider) Schema(
 }
 
 type dbtCloudProviderModel struct {
-	Token                types.String `tfsdk:"token"`
-	AccountID            types.Int64  `tfsdk:"account_id"`
-	HostURL              types.String `tfsdk:"host_url"`
-	MaxRetries           types.Int64  `tfsdk:"max_retries"`
-	RetryIntervalSeconds types.Int64  `tfsdk:"retry_interval_seconds"`
-	DisableRetry         types.Bool   `tfsdk:"disable_retry"`
-	RetriableStatusCodes types.List   `tfsdk:"retriable_status_codes"`
+	Token                     types.String `tfsdk:"token"`
+	AccountID                 types.Int64  `tfsdk:"account_id"`
+	HostURL                   types.String `tfsdk:"host_url"`
+	MaxRetries                types.Int64  `tfsdk:"max_retries"`
+	RetryIntervalSeconds      types.Int64  `tfsdk:"retry_interval_seconds"`
+	DisableRetry              types.Bool   `tfsdk:"disable_retry"`
+	SkipCredentialsValidation types.Bool   `tfsdk:"skip_credentials_validation"`
+	RetriableStatusCodes      types.List   `tfsdk:"retriable_status_codes"`
 }
 
 func (p *dbtCloudProvider) Configure(
@@ -257,7 +262,9 @@ func (p *dbtCloudProvider) Configure(
 		}
 	}
 
-	client, err := dbt_cloud.NewClient(&accountID, &token, &hostURL, &maxRetries, &retryIntervalSeconds, retriableStatusCodes)
+	skipCredentialsValidation := config.SkipCredentialsValidation.ValueBool()
+
+	client, err := dbt_cloud.NewClient(&accountID, &token, &hostURL, &maxRetries, &retryIntervalSeconds, retriableStatusCodes, skipCredentialsValidation)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create dbt Cloud API Client",


### PR DESCRIPTION
This change adds a new optional boolean flag `skip_credentials_validation` to the dbt Cloud provider, similar to the AWS provider implementation.

When set to true, the provider will skip the API call that validates credentials during initialization. This is useful for:
- Testing scenarios where credential validation is not needed
- Custom dbt Cloud API implementations without standard authentication
- Environments where the validation endpoint may not be available

The flag defaults to false to maintain backward compatibility.

Changes:
- Added skip_credentials_validation to provider schema
- Added SkipCredentialsValidation to provider model
- Updated Configure method to pass flag to client
- Modified NewClient signature to accept skipCredentialsValidation parameter
- Updated validation logic to respect the skip flag
- Updated provider documentation