### PR TITLE
Validation for athena s3 path

### DIFF
--- a/.changes/unreleased/Changes-20251117-103640.yaml
+++ b/.changes/unreleased/Changes-20251117-103640.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: Validation for athena s3 path
+time: 2025-11-17T10:36:40.147588+02:00

--- a/docs/data-sources/global_connection.md
+++ b/docs/data-sources/global_connection.md
@@ -71,10 +71,10 @@ Read-Only:
 - `num_retries` (Number) Number of times to retry a failing query.
 - `poll_interval` (Number) Interval in seconds to use for polling the status of query results in Athena.
 - `region_name` (String) AWS region of your Athena instance.
-- `s3_data_dir` (String) Prefix for storing tables, if different from the connection's S3 staging directory.
+- `s3_data_dir` (String) Prefix for storing tables, if different from the connection's S3 staging directory. Must be in the format 's3://bucket-name/path/'.
 - `s3_data_naming` (String) How to generate table paths in the S3 data directory.
-- `s3_staging_dir` (String) S3 location to store Athena query results and metadata.
-- `s3_tmp_table_dir` (String) Prefix for storing temporary tables, if different from the connection's S3 data directory.
+- `s3_staging_dir` (String) S3 location to store Athena query results and metadata. Must be in the format 's3://bucket-name/path/'.
+- `s3_tmp_table_dir` (String) Prefix for storing temporary tables, if different from the connection's S3 data directory. Must be in the format 's3://bucket-name/path/'.
 - `spark_work_group` (String) Identifier of Athena Spark workgroup for running Python models.
 - `work_group` (String) Identifier of Athena workgroup.
 

--- a/docs/resources/global_connection.md
+++ b/docs/resources/global_connection.md
@@ -32,9 +32,10 @@ resource "dbtcloud_global_connection" "athena" {
   athena = {
     region_name    = "us-east-1"
     database       = "mydatabase"
-    s3_staging_dir = "my_dir"
+    s3_staging_dir = "s3://my-bucket/my-staging-dir/"
     // example of optional fields
-    work_group = "my_work_group"
+    work_group     = "my_work_group"
+    s3_data_dir    = "s3://my-bucket/my-data-dir/"
   }
 }
 
@@ -207,7 +208,7 @@ Required:
 
 - `database` (String) Specify the database (data catalog) to build models into (lowercase only).
 - `region_name` (String) AWS region of your Athena instance.
-- `s3_staging_dir` (String) S3 location to store Athena query results and metadata.
+- `s3_staging_dir` (String) S3 location to store Athena query results and metadata. Must be in the format 's3://bucket-name/path/'.
 
 Optional:
 
@@ -215,9 +216,9 @@ Optional:
 - `num_iceberg_retries` (Number) Number of times to retry iceberg commit queries to fix ICEBERG_COMMIT_ERROR.
 - `num_retries` (Number) Number of times to retry a failing query.
 - `poll_interval` (Number) Interval in seconds to use for polling the status of query results in Athena.
-- `s3_data_dir` (String) Prefix for storing tables, if different from the connection's S3 staging directory.
+- `s3_data_dir` (String) Prefix for storing tables, if different from the connection's S3 staging directory. Must be in the format 's3://bucket-name/path/'.
 - `s3_data_naming` (String) How to generate table paths in the S3 data directory.
-- `s3_tmp_table_dir` (String) Prefix for storing temporary tables, if different from the connection's S3 data directory.
+- `s3_tmp_table_dir` (String) Prefix for storing temporary tables, if different from the connection's S3 data directory. Must be in the format 's3://bucket-name/path/'.
 - `spark_work_group` (String) Identifier of Athena Spark workgroup for running Python models.
 - `work_group` (String) Identifier of Athena workgroup.
 

--- a/examples/resources/dbtcloud_global_connection/resource.tf
+++ b/examples/resources/dbtcloud_global_connection/resource.tf
@@ -14,9 +14,10 @@ resource "dbtcloud_global_connection" "athena" {
   athena = {
     region_name    = "us-east-1"
     database       = "mydatabase"
-    s3_staging_dir = "my_dir"
+    s3_staging_dir = "s3://my-bucket/my-staging-dir/"
     // example of optional fields
-    work_group = "my_work_group"
+    work_group     = "my_work_group"
+    s3_data_dir    = "s3://my-bucket/my-data-dir/"
   }
 }
 

--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -1383,7 +1383,7 @@ resource dbtcloud_global_connection test {
   athena = {
     region_name = "region"
     database = "database"
-    s3_staging_dir = "s3_staging_dir"
+    s3_staging_dir = "s3://test-bucket/staging/"
   }
 }
 
@@ -1400,12 +1400,12 @@ resource dbtcloud_global_connection test {
   athena = {
     region_name = "region"
     database = "database2"
-    s3_staging_dir = "other_s3_staging_dir"
+    s3_staging_dir = "s3://test-bucket/other-staging/"
     work_group = "work_group" 
     spark_work_group = "spark_work_group"
-    s3_data_dir = "s3_data_dir"
+    s3_data_dir = "s3://test-bucket/data/"
     s3_data_naming = "s3_data_naming"
-    s3_tmp_table_dir = "s3_tmp_table_dir"
+    s3_tmp_table_dir = "s3://test-bucket/tmp/"
     poll_interval = 123
     num_retries = 2
     num_boto3_retries = 3

--- a/pkg/framework/objects/global_connection/schema.go
+++ b/pkg/framework/objects/global_connection/schema.go
@@ -3,6 +3,7 @@ package global_connection
 import (
 	"context"
 
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/objects/global_connection/validators"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -184,7 +185,7 @@ func (r *globalConnectionResource) Schema(
 									types.StringValue("https://www.googleapis.com/auth/drive"),
 								},
 							),
-						),	
+						),
 						Description: "OAuth scopes for the BigQuery connection",
 					},
 					"use_latest_adapter": resource_schema.BoolAttribute{
@@ -475,7 +476,10 @@ func (r *globalConnectionResource) Schema(
 					},
 					"s3_staging_dir": resource_schema.StringAttribute{
 						Required:    true,
-						Description: "S3 location to store Athena query results and metadata.",
+						Description: "S3 location to store Athena query results and metadata. Must be in the format 's3://bucket-name/path/'.",
+						Validators: []validator.String{
+							validators.S3PathValidator{},
+						},
 					},
 					"work_group": resource_schema.StringAttribute{
 						Optional:    true,
@@ -487,7 +491,10 @@ func (r *globalConnectionResource) Schema(
 					},
 					"s3_data_dir": resource_schema.StringAttribute{
 						Optional:    true,
-						Description: "Prefix for storing tables, if different from the connection's S3 staging directory.",
+						Description: "Prefix for storing tables, if different from the connection's S3 staging directory. Must be in the format 's3://bucket-name/path/'.",
+						Validators: []validator.String{
+							validators.S3PathValidator{},
+						},
 					},
 					"s3_data_naming": resource_schema.StringAttribute{
 						Optional:    true,
@@ -495,7 +502,10 @@ func (r *globalConnectionResource) Schema(
 					},
 					"s3_tmp_table_dir": resource_schema.StringAttribute{
 						Optional:    true,
-						Description: "Prefix for storing temporary tables, if different from the connection's S3 data directory.",
+						Description: "Prefix for storing temporary tables, if different from the connection's S3 data directory. Must be in the format 's3://bucket-name/path/'.",
+						Validators: []validator.String{
+							validators.S3PathValidator{},
+						},
 					},
 					"poll_interval": resource_schema.Int64Attribute{
 						Optional:    true,
@@ -993,7 +1003,7 @@ func (r *globalConnectionDataSource) Schema(
 					},
 					"s3_staging_dir": datasource_schema.StringAttribute{
 						Computed:    true,
-						Description: "S3 location to store Athena query results and metadata.",
+						Description: "S3 location to store Athena query results and metadata. Must be in the format 's3://bucket-name/path/'.",
 					},
 					"work_group": datasource_schema.StringAttribute{
 						Computed:    true,
@@ -1005,7 +1015,7 @@ func (r *globalConnectionDataSource) Schema(
 					},
 					"s3_data_dir": datasource_schema.StringAttribute{
 						Computed:    true,
-						Description: "Prefix for storing tables, if different from the connection's S3 staging directory.",
+						Description: "Prefix for storing tables, if different from the connection's S3 staging directory. Must be in the format 's3://bucket-name/path/'.",
 					},
 					"s3_data_naming": datasource_schema.StringAttribute{
 						Computed:    true,
@@ -1013,7 +1023,7 @@ func (r *globalConnectionDataSource) Schema(
 					},
 					"s3_tmp_table_dir": datasource_schema.StringAttribute{
 						Computed:    true,
-						Description: "Prefix for storing temporary tables, if different from the connection's S3 data directory.",
+						Description: "Prefix for storing temporary tables, if different from the connection's S3 data directory. Must be in the format 's3://bucket-name/path/'.",
 					},
 					"poll_interval": datasource_schema.Int64Attribute{
 						Computed:    true,

--- a/pkg/framework/objects/global_connection/validators/s3_path_validator.go
+++ b/pkg/framework/objects/global_connection/validators/s3_path_validator.go
@@ -1,0 +1,59 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+type S3PathValidator struct{}
+
+func (v S3PathValidator) Description(ctx context.Context) string {
+	return "Validates that the S3 path starts with 's3://' and follows the correct S3 URI format."
+}
+
+func (v S3PathValidator) MarkdownDescription(ctx context.Context) string {
+	return "Validates that the S3 path starts with `s3://` and follows the correct S3 URI format."
+}
+
+func (v S3PathValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	// Skip validation if the value is unknown or null
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	// Get the value
+	s3Path := req.ConfigValue.ValueString()
+
+	// Check if the path starts with s3://
+	if !strings.HasPrefix(s3Path, "s3://") {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid S3 Path Format",
+			fmt.Sprintf("The S3 path must start with 's3://'. Got: %s\nExample: s3://my-bucket/my-path/", s3Path),
+		)
+		return
+	}
+
+	// Check if there's content after s3://
+	bucketAndPath := strings.TrimPrefix(s3Path, "s3://")
+	if bucketAndPath == "" {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid S3 Path Format",
+			fmt.Sprintf("The S3 path must include a bucket name after 's3://'. Got: %s\nExample: s3://my-bucket/my-path/", s3Path),
+		)
+		return
+	}
+
+	// Check if path ends with a slash (best practice for S3 directory paths)
+	if !strings.HasSuffix(s3Path, "/") {
+		resp.Diagnostics.AddAttributeWarning(
+			req.Path,
+			"S3 Path Format Recommendation",
+			fmt.Sprintf("The S3 path should typically end with a trailing slash for directory paths. Got: %s\nRecommended: %s/", s3Path, s3Path),
+		)
+	}
+}


### PR DESCRIPTION
### Overview
Adds validation to prevent incorrect S3 path formats in Athena connection configurations, catching errors at plan/apply time instead of job runtime.

### Changes
**✨ New Validator**

- Created S3PathValidator for Athena S3 fields
- Validates paths start with s3:// and include a bucket name
- Provides helpful error messages with examples

### 📝 Updated Fields
Applied validation to:

- s3_staging_dir (required)
- s3_data_dir (optional)
- s3_tmp_table_dir (optional)

### 📚 Documentation

- Updated field descriptions with format requirements
- Fixed all examples to use correct S3 URIs
- Updated acceptance tests

**Example**
Before: ❌
`s3_staging_dir = "my-bucket"  # Fails at job runtime`
After: ✅
`s3_staging_dir = "s3://my-bucket/staging/"  # Validated at plan time`

**Error Message**
```
Error: Invalid S3 Path Format

The S3 path must start with 's3://'. Got: my-bucket
Example: s3://my-bucket/my-path/
Error: Invalid S3 Path FormatThe S3 path must start with 's3://'. Got: my-bucketExample: s3://my-bucket/my-path/
```