### PR TITLE
Delete lingering Group if permission update fails

### DIFF
--- a/.changes/unreleased/Fixes-20251209-103157.yaml
+++ b/.changes/unreleased/Fixes-20251209-103157.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Lingering group deleted if permissions update fails
+time: 2025-12-09T10:31:57.245811+02:00

--- a/pkg/framework/objects/group/resource.go
+++ b/pkg/framework/objects/group/resource.go
@@ -123,8 +123,19 @@ func (r *groupResource) Create(
 			"Unable to assign permissions to the group",
 			"Error: "+err.Error(),
 		)
+
+		// Delete the group if the permissions update fails
+		createdGroup.State = dbt_cloud.STATE_DELETED
+		_, deleteErr := r.client.UpdateGroup(*createdGroup.ID, *createdGroup)
+		if deleteErr != nil {
+			resp.Diagnostics.AddError(
+				"Unable to delete group after permissions failure",
+				"Error: "+deleteErr.Error(),
+			)
+		}
 		return
 	}
+
 	plan.ID = types.Int64Value(int64(*createdGroup.ID))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }


### PR DESCRIPTION
In the case where a permission cannot be added to a certain group, for reasons like a missing account-level setting, feature flag and so on, the Group gets created but when the Permission addition fails the Group remains empty and is not added to the TF state.
This change aims to solve that issue by deleting the lingering Group in case of permission update failure.