### PR TITLE
Allow rename of env without re-create, this is consistent with the UI

### DIFF
--- a/.changes/unreleased/Fixes-20251215-101305.yaml
+++ b/.changes/unreleased/Fixes-20251215-101305.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Allow rename of env without re-create
+time: 2025-12-15T10:13:05.283591+02:00

--- a/pkg/framework/objects/environment/schema.go
+++ b/pkg/framework/objects/environment/schema.go
@@ -198,9 +198,6 @@ func (r *environmentResource) Schema(
 			"name": resource_schema.StringAttribute{
 				Required:    true,
 				Description: "The name of the environment",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"dbt_version": resource_schema.StringAttribute{
 				Computed:    true,


### PR DESCRIPTION
**Problem:**
Renaming an environment forced its recreation, even though the dbt Cloud API and UI support renaming without recreation.

**Root Cause:**
The name attribute had an unnecessary `RequiresReplace()` plan modifier.

**Fix:**
Removed `RequiresReplace() `from the environment `name` attribute. The Update function already handles name changes correctly.