### PR TITLE
Fix partial group permission delete operation does not return after error

### DIFF
--- a/.changes/unreleased/Fixes-20251215-164152.yaml
+++ b/.changes/unreleased/Fixes-20251215-164152.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Return if a partial group permission delete fails
+time: 2025-12-15T16:41:52.589366+02:00

--- a/pkg/framework/objects/group_partial_permissions/resource.go
+++ b/pkg/framework/objects/group_partial_permissions/resource.go
@@ -265,6 +265,7 @@ func (r *groupPartialPermissionsResource) Delete(
 			"Issue getting Group",
 			"Error: "+err.Error(),
 		)
+		return
 	}
 
 	remotePermissions := group.ConvertGroupPermissionDataToModel(retrievedGroup.Permissions)


### PR DESCRIPTION
**Problem**
Terraform provider crashed with panic

**Root cause**
The issue happened during a `delete` action for the partial group permission resource, so the issue must be caused by improper returning when an error is thrown. If the group permission object is not found, the error is logged but the execution in the method continues, and then the `retrievedGroup.Permissions` property is accessed. This causes a null ref error.

**Fix**
Return in case there is an error in the delete action of the partial group permissions resource.