### PR TITLE
Ensure use_custom_branch and custom_branch value are cohesive

### DIFF
--- a/.changes/unreleased/Behind the scenes-20251215-172613.yaml
+++ b/.changes/unreleased/Behind the scenes-20251215-172613.yaml
@@ -1,0 +1,3 @@
+kind: Behind the scenes
+body: Custom branch and use custom branch must match
+time: 2025-12-15T17:26:13.609056+02:00

--- a/pkg/framework/objects/environment/env_optional_params_test.go
+++ b/pkg/framework/objects/environment/env_optional_params_test.go
@@ -168,6 +168,7 @@ resource "dbtcloud_environment" "test_env" {
   project_id = dbtcloud_project.test_project.id
   connection_id = dbtcloud_global_connection.test.id
 
+  use_custom_branch = true
   custom_branch = "%s"
   deployment_type = "%s"
 

--- a/pkg/framework/objects/environment/schema.go
+++ b/pkg/framework/objects/environment/schema.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"context"
 
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/objects/environment/validators"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -223,10 +224,16 @@ func (r *environmentResource) Schema(
 				Optional:    true,
 				Default:     booldefault.StaticBool(false),
 				Description: "Whether to use a custom git branch in this environment",
+				Validators: []validator.Bool{
+					validators.UseCustomBranchValidator{},
+				},
 			},
 			"custom_branch": resource_schema.StringAttribute{
 				Optional:    true,
 				Description: "The custom branch name to use",
+				Validators: []validator.String{
+					validators.CustomBranchValidator{},
+				},
 			},
 			"deployment_type": resource_schema.StringAttribute{
 				Optional:    true,

--- a/pkg/framework/objects/environment/validators/custom_branch_validator.go
+++ b/pkg/framework/objects/environment/validators/custom_branch_validator.go
@@ -1,0 +1,88 @@
+package validators
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// CustomBranchValidator validates that custom_branch is set when use_custom_branch is true.
+// This validator should be attached to the custom_branch field.
+type CustomBranchValidator struct{}
+
+func (v CustomBranchValidator) Description(ctx context.Context) string {
+	return "Validates that custom_branch must be set when use_custom_branch is true, and use_custom_branch must be true when custom_branch is set."
+}
+
+func (v CustomBranchValidator) MarkdownDescription(ctx context.Context) string {
+	return "Validates that `custom_branch` must be set when `use_custom_branch` is true, and `use_custom_branch` must be true when `custom_branch` is set."
+}
+
+func (v CustomBranchValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	// Get the value of use_custom_branch
+	var useCustomBranch types.Bool
+	useCustomBranchPath := path.Root("use_custom_branch")
+	diags := req.Config.GetAttribute(ctx, useCustomBranchPath, &useCustomBranch)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	customBranchIsSet := !req.ConfigValue.IsNull() && req.ConfigValue.ValueString() != ""
+
+	// If custom_branch is set but use_custom_branch is false
+	if customBranchIsSet && !useCustomBranch.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Inconsistent custom branch configuration",
+			"When custom_branch is specified, use_custom_branch must be set to true. "+
+				"Either set use_custom_branch to true or remove the custom_branch attribute.",
+		)
+	}
+}
+
+// UseCustomBranchValidator validates that use_custom_branch requires custom_branch to be set.
+// This validator should be attached to the use_custom_branch field.
+type UseCustomBranchValidator struct{}
+
+func (v UseCustomBranchValidator) Description(ctx context.Context) string {
+	return "Validates that custom_branch must be set when use_custom_branch is true."
+}
+
+func (v UseCustomBranchValidator) MarkdownDescription(ctx context.Context) string {
+	return "Validates that `custom_branch` must be set when `use_custom_branch` is true."
+}
+
+func (v UseCustomBranchValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	// Skip validation if use_custom_branch is unknown or null
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	// If use_custom_branch is false, no need to check for custom_branch
+	if !req.ConfigValue.ValueBool() {
+		return
+	}
+
+	// Get the value of custom_branch
+	var customBranch types.String
+	customBranchPath := path.Root("custom_branch")
+	diags := req.Config.GetAttribute(ctx, customBranchPath, &customBranch)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	customBranchIsSet := !customBranch.IsNull() && customBranch.ValueString() != ""
+
+	// If use_custom_branch is true but custom_branch is not set
+	if !customBranchIsSet {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Missing custom_branch",
+			"When use_custom_branch is set to true, custom_branch must be specified.",
+		)
+	}
+}


### PR DESCRIPTION
**Problem**
When `custom_branch` was set but `use_custom_branch` was false (or not set), the environment configuration would be inconsistent - the API would receive conflicting values, causing confusing behavior in the dbt Cloud UI.

**Solution**
Added schema validators to ensure `use_custom_branch` and `custom_branch` are used consistently:
Error if `custom_branch` is set but `use_custom_branch` is false
Error if `use_custom_branch` is true but `custom_branch` is not set

**Changes**
Added validators/custom_branch_validator.go with CustomBranchValidator and UseCustomBranchValidator
Added validators to the use_custom_branch and custom_branch schema fields
Added acceptance tests for both validation scenarios
Fixed existing test that was setting custom_branch without use_custom_branch = true