### PR TITLE
Fix error handling in Semantic Layer credential Read() functions

### DIFF
--- a/.changes/unreleased/Fixes-20251219-124733.yaml
+++ b/.changes/unreleased/Fixes-20251219-124733.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: On SL cred no found, log properly and remove from state
+time: 2025-12-19T12:47:33.286836+02:00

--- a/pkg/framework/objects/semantic_layer_credential/bigquery_sl_credential_resource.go
+++ b/pkg/framework/objects/semantic_layer_credential/bigquery_sl_credential_resource.go
@@ -53,8 +53,6 @@ func (r *bigQuerySemanticLayerCredentialResource) Read(
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Error getting the Semantic Layer configuration", err.Error())
-
 		resp.Diagnostics.AddError(
 			"Issue getting Semantic Layer credential",
 			"Error: "+err.Error(),
@@ -69,7 +67,6 @@ func (r *bigQuerySemanticLayerCredentialResource) Read(
 	state.Configuration.ProjectID = types.Int64Value(int64(credential.ProjectID))
 	state.Configuration.Name = types.StringValue(credential.Name)
 	state.Configuration.AdapterVersion = types.StringValue(credential.AdapterVersion)
-
 
 	state.AuthURI = getStringFromMap(credential.Values, "auth_uri")
 	state.TokenURI = getStringFromMap(credential.Values, "token_uri")

--- a/pkg/framework/objects/semantic_layer_credential/databricks_sl_credential_resource.go
+++ b/pkg/framework/objects/semantic_layer_credential/databricks_sl_credential_resource.go
@@ -43,12 +43,7 @@ func (r *databricksSemanticLayerCredentialResource) Read(
 	}
 
 	credential, err := r.client.GetSemanticLayerCredential(state.ID.ValueInt64())
-
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Issue getting Semantic Layer credential",
-			"Error: "+err.Error(),
-		)
 		if strings.HasPrefix(err.Error(), "resource-not-found") {
 			resp.Diagnostics.AddWarning(
 				"Resource not found",
@@ -57,7 +52,10 @@ func (r *databricksSemanticLayerCredentialResource) Read(
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Error getting the Semantic Layer configuration", err.Error())
+		resp.Diagnostics.AddError(
+			"Issue getting Semantic Layer credential",
+			"Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/pkg/framework/objects/semantic_layer_credential/postgres_sl_credential_resource.go
+++ b/pkg/framework/objects/semantic_layer_credential/postgres_sl_credential_resource.go
@@ -45,11 +45,6 @@ func (r *postgresSemanticLayerCredentialResource) Read(
 
 	credential, err := r.client.GetSemanticLayerCredential(id)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Issue getting Semantic Layer credential",
-			"Error: "+err.Error(),
-		)
-
 		if strings.HasPrefix(err.Error(), "resource-not-found") {
 			resp.Diagnostics.AddWarning(
 				"Resource not found",
@@ -58,6 +53,10 @@ func (r *postgresSemanticLayerCredentialResource) Read(
 			resp.State.RemoveResource(ctx)
 			return
 		}
+		resp.Diagnostics.AddError(
+			"Issue getting Semantic Layer credential",
+			"Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/pkg/framework/objects/semantic_layer_credential/redshift_sl_credential_resource.go
+++ b/pkg/framework/objects/semantic_layer_credential/redshift_sl_credential_resource.go
@@ -45,11 +45,6 @@ func (r *redshiftSemanticLayerCredentialResource) Read(
 
 	credential, err := r.client.GetSemanticLayerCredential(id)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Issue getting Semantic Layer credential",
-			"Error: "+err.Error(),
-		)
-
 		if strings.HasPrefix(err.Error(), "resource-not-found") {
 			resp.Diagnostics.AddWarning(
 				"Resource not found",
@@ -58,7 +53,10 @@ func (r *redshiftSemanticLayerCredentialResource) Read(
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Error getting the Semantic Layer configuration", err.Error())
+		resp.Diagnostics.AddError(
+			"Issue getting Semantic Layer credential",
+			"Error: "+err.Error(),
+		)
 		return
 	}
 

--- a/pkg/framework/objects/semantic_layer_credential/snowflake_sl_credential_resource.go
+++ b/pkg/framework/objects/semantic_layer_credential/snowflake_sl_credential_resource.go
@@ -45,10 +45,6 @@ func (r *snowflakeSemanticLayerCredentialResource) Read(
 
 	credential, err := r.client.GetSemanticLayerCredential(id)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Issue getting Semantic Layer credential",
-			"Error: "+err.Error(),
-		)
 		if strings.HasPrefix(err.Error(), "resource-not-found") {
 			resp.Diagnostics.AddWarning(
 				"Resource not found",
@@ -57,7 +53,10 @@ func (r *snowflakeSemanticLayerCredentialResource) Read(
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Error getting the Semantic Layer configuration", err.Error())
+		resp.Diagnostics.AddError(
+			"Issue getting Semantic Layer credential",
+			"Error: "+err.Error(),
+		)
 		return
 	}
 


### PR DESCRIPTION
**Problem**
When a Semantic Layer credential was deleted outside of Terraform, the Read() function would incorrectly add both an error AND a warning before removing the resource from state. This caused confusing output and could leave Terraform state in an inconsistent condition.

**Solution**
Fixed the error handling order in all 5 SL credential resources to:

1. Check for resource-not-found first
2. Add only a warning (not an error) when gracefully removing deleted resources from state
3. Remove duplicate error messages
