### PR TITLE
Fix multiline for execute steps

### DIFF
--- a/.changes/unreleased/Fixes-20260113-163302.yaml
+++ b/.changes/unreleased/Fixes-20260113-163302.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fix multiline for execute steps
+time: 2026-01-13T16:33:02.500496+02:00

--- a/pkg/framework/objects/job/resource.go
+++ b/pkg/framework/objects/job/resource.go
@@ -877,8 +877,13 @@ func (j *jobResource) validateExecuteSteps(executeSteps []string) error {
 
 	// Validate each execute step individually
 	for _, step := range executeSteps {
+		// Normalize the step by replacing newlines with spaces to support multi-line commands
+		// This matches how dbt Cloud UI handles commands that span multiple lines
+		normalizedStep := strings.ReplaceAll(step, "\n", " ")
+		normalizedStep = strings.ReplaceAll(normalizedStep, "\r", " ")
+
 		// Check if step matches valid dbt command pattern
-		if !validCommandsRegex.MatchString(step) {
+		if !validCommandsRegex.MatchString(normalizedStep) {
 			return fmt.Errorf("invalid command: %s. Allowed commands are: %s", step, strings.Join(dbt_commands, ", "))
 		}
 


### PR DESCRIPTION
**Problem**
The regex pattern used for validation (^\s*dbt\s+....*$) doesn't match newline characters with .*, causing multi-line commands like the following to fail validation:
```
execute_steps = [<<-EOT
dbt run --select    
  my_project,config.materialized:view,state:modified,tag:my_tag    
  my_project,config.materialized:table,tag:my_tag    
  my_project,config.materialized:incremental,tag:my_tag
EOT
]
```

**Solution**
Normalize commands by replacing newlines (\n and \r) with spaces before running the regex validation. This matches how dbt Cloud interprets these commands - newlines are treated as whitespace separators.