### PR TITLE
Enable execution block and timeout_seconds

### DIFF
--- a/.changes/unreleased/Changes-20260116-155106.yaml
+++ b/.changes/unreleased/Changes-20260116-155106.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: Fixed timout_seconds missing field
+time: 2026-01-16T15:51:06.20357+02:00

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -45,6 +45,11 @@ resource "dbtcloud_job" "daily_job" {
   schedule_days  = [0, 1, 2, 3, 4, 5, 6]
   schedule_type  = "days_of_week"
   schedule_hours = [0]
+
+  # set job timeout using the execution block (recommended)
+  execution = {
+    timeout_seconds = 1800
+  }
 }
 
 
@@ -73,6 +78,11 @@ resource "dbtcloud_job" "ci_job" {
   # this is not going to be used when schedule is set to false
   schedule_days = [0, 1, 2, 3, 4, 5, 6]
   schedule_type = "days_of_week"
+
+  # set job timeout - use execution block (recommended) instead of the deprecated timeout_seconds
+  execution = {
+    timeout_seconds = 3600
+  }
 }
 
 # a job that is set to be triggered after another job finishes
@@ -213,6 +223,7 @@ An example can be found [in this GitHub issue](https://github.com/dbt-labs/terra
 - `deferring_job_id` (Number) Job identifier that this job defers to (legacy deferring approach)
 - `description` (String) Description for the job
 - `errors_on_lint_failure` (Boolean) Whether the CI job should fail when a lint error is found. Only used when `run_lint` is set to `true`. Defaults to `true`.
+- `execution` (Attributes) Execution settings for the job (see [below for nested schema](#nestedatt--execution))
 - `force_node_selection` (Boolean) Whether to force node selection (SAO - Select All Optimizations) for the job. If `dbt_version` is not set to `latest-fusion`, this must be set to `true` when specified.
 - `generate_docs` (Boolean) Flag for whether the job should generate documentation
 - `is_active` (Boolean) Should always be set to true as setting it to false is the same as creating a job in a deleted state. To create/keep a job in a 'deactivated' state, check  the `triggers` config. Setting it to false essentially deletes the job. On resource creation, this field is enforced to be true.
@@ -229,7 +240,7 @@ An example can be found [in this GitHub issue](https://github.com/dbt-labs/terra
 - `schedule_type` (String) Type of schedule to use, one of every_day/ days_of_week/ custom_cron/ interval_cron
 - `self_deferring` (Boolean) Whether this job defers on a previous run of itself
 - `target_name` (String) Target name for the dbt profile
-- `timeout_seconds` (Number, Deprecated) [Deprectated - Moved to execution.timeout_seconds] Number of seconds to allow the job to run before timing out
+- `timeout_seconds` (Number, Deprecated) Number of seconds to allow the job to run before timing out. Use execution.timeout_seconds instead.
 - `triggers_on_draft_pr` (Boolean) Whether the CI job should be automatically triggered on draft PRs
 - `validate_execute_steps` (Boolean) When set to `true`, the provider will validate the `execute_steps` during plan time to ensure they contain valid dbt commands. If a command is not recognized (e.g., a new dbt command not yet supported by the provider), the validation will fail. Defaults to `false` to allow flexibility with newer dbt commands.
 
@@ -247,6 +258,14 @@ Optional:
 - `github_webhook` (Boolean) Whether the job runs automatically on PR creation
 - `on_merge` (Boolean) Whether the job runs automatically once a PR is merged
 - `schedule` (Boolean) Whether the job runs on a schedule
+
+
+<a id="nestedatt--execution"></a>
+### Nested Schema for `execution`
+
+Optional:
+
+- `timeout_seconds` (Number) The number of seconds before the job times out
 
 
 <a id="nestedblock--job_completion_trigger_condition"></a>

--- a/examples/resources/dbtcloud_job/resource.tf
+++ b/examples/resources/dbtcloud_job/resource.tf
@@ -22,6 +22,11 @@ resource "dbtcloud_job" "daily_job" {
   schedule_days  = [0, 1, 2, 3, 4, 5, 6]
   schedule_type  = "days_of_week"
   schedule_hours = [0]
+
+  # set job timeout using the execution block (recommended)
+  execution = {
+    timeout_seconds = 1800
+  }
 }
 
 
@@ -50,6 +55,11 @@ resource "dbtcloud_job" "ci_job" {
   # this is not going to be used when schedule is set to false
   schedule_days = [0, 1, 2, 3, 4, 5, 6]
   schedule_type = "days_of_week"
+
+  # set job timeout - use execution block (recommended) instead of the deprecated timeout_seconds
+  execution = {
+    timeout_seconds = 3600
+  }
 }
 
 # a job that is set to be triggered after another job finishes

--- a/pkg/framework/objects/job/model.go
+++ b/pkg/framework/objects/job/model.go
@@ -101,8 +101,8 @@ type SingleJobDataSourceModel struct {
 }
 
 type JobResourceModel struct {
-	// Execution                     *JobExecution         `tfsdk:"execution"`            // has timeout-seconds
-	TimeoutSeconds         types.Int64    `tfsdk:"timeout_seconds"`          // moved under execution , add deprecation message
+	Execution              *JobExecution  `tfsdk:"execution"`
+	TimeoutSeconds         types.Int64    `tfsdk:"timeout_seconds"`          // deprecated, use Execution.TimeoutSeconds
 	GenerateDocs           types.Bool     `tfsdk:"generate_docs"`            // exists
 	RunGenerateSources     types.Bool     `tfsdk:"run_generate_sources"`     // exists
 	ID                     types.Int64    `tfsdk:"id"`                       // will hold job id?

--- a/pkg/framework/objects/job/resource_acceptance_timeout_test.go
+++ b/pkg/framework/objects/job/resource_acceptance_timeout_test.go
@@ -1,0 +1,331 @@
+package job_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_config"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccDbtCloudJobResourceTimeoutSecondsBackwardCompatibility tests that the
+// deprecated top-level timeout_seconds attribute still works for backward compatibility
+func TestAccDbtCloudJobResourceTimeoutSecondsBackwardCompatibility(t *testing.T) {
+	jobName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create job with deprecated timeout_seconds
+				Config: testAccDbtCloudJobResourceTimeoutConfig(
+					jobName,
+					projectName,
+					environmentName,
+					"deprecated", // uses top-level timeout_seconds
+					180,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "name", jobName),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "timeout_seconds", "180"),
+				),
+			},
+			// Update the timeout value using deprecated attribute
+			{
+				Config: testAccDbtCloudJobResourceTimeoutConfig(
+					jobName,
+					projectName,
+					environmentName,
+					"deprecated",
+					360,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "timeout_seconds", "360"),
+				),
+			},
+			// Import and verify
+			{
+				ResourceName:      "dbtcloud_job.test_job",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"triggers.%",
+					"triggers.custom_branch_only",
+					"validate_execute_steps",
+				},
+			},
+		},
+	})
+}
+
+// TestAccDbtCloudJobResourceExecutionTimeoutSeconds tests that the new
+// execution.timeout_seconds attribute works correctly
+func TestAccDbtCloudJobResourceExecutionTimeoutSeconds(t *testing.T) {
+	jobName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create job with new execution.timeout_seconds
+				Config: testAccDbtCloudJobResourceTimeoutConfig(
+					jobName,
+					projectName,
+					environmentName,
+					"execution", // uses execution block
+					240,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "name", jobName),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "execution.timeout_seconds", "240"),
+					// When using execution block, deprecated timeout_seconds keeps its default (0)
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "timeout_seconds", "0"),
+				),
+			},
+			// Update the timeout value using execution block
+			{
+				Config: testAccDbtCloudJobResourceTimeoutConfig(
+					jobName,
+					projectName,
+					environmentName,
+					"execution",
+					480,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "execution.timeout_seconds", "480"),
+					// When using execution block, deprecated timeout_seconds keeps its default (0)
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "timeout_seconds", "0"),
+				),
+			},
+			// Import and verify
+			{
+				ResourceName:      "dbtcloud_job.test_job",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"triggers.%",
+					"triggers.custom_branch_only",
+					"validate_execute_steps",
+					"execution",       // execution block is only set if user configured it
+					"timeout_seconds", // after import, this gets API value since we don't know user's config preference
+				},
+			},
+		},
+	})
+}
+
+// TestAccDbtCloudJobResourceTimeoutSecondsPrecedence tests that when both
+// deprecated timeout_seconds and execution.timeout_seconds are set,
+// execution.timeout_seconds takes precedence
+func TestAccDbtCloudJobResourceTimeoutSecondsPrecedence(t *testing.T) {
+	jobName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create job with both timeout settings - execution should take precedence
+				Config: testAccDbtCloudJobResourceTimeoutBothConfig(
+					jobName,
+					projectName,
+					environmentName,
+					100, // deprecated timeout_seconds (ignored when execution is set)
+					300, // execution.timeout_seconds (should win)
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "name", jobName),
+					// execution.timeout_seconds takes precedence and is used for the API call
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "execution.timeout_seconds", "300"),
+					// When execution block is used, timeout_seconds keeps its configured value
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "timeout_seconds", "100"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDbtCloudJobResourceTimeoutSecondsMigration tests migrating from
+// deprecated timeout_seconds to the new execution.timeout_seconds
+func TestAccDbtCloudJobResourceTimeoutSecondsMigration(t *testing.T) {
+	jobName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Start with deprecated timeout_seconds
+				Config: testAccDbtCloudJobResourceTimeoutConfig(
+					jobName,
+					projectName,
+					environmentName,
+					"deprecated",
+					180,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "timeout_seconds", "180"),
+				),
+			},
+			// Migrate to execution.timeout_seconds
+			{
+				Config: testAccDbtCloudJobResourceTimeoutConfig(
+					jobName,
+					projectName,
+					environmentName,
+					"execution",
+					180,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "execution.timeout_seconds", "180"),
+					// After migration, deprecated timeout_seconds goes back to default (0)
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "timeout_seconds", "0"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDbtCloudJobResourceTimeoutSecondsDefault tests that when neither
+// timeout is specified, it defaults to 0
+func TestAccDbtCloudJobResourceTimeoutSecondsDefault(t *testing.T) {
+	jobName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create job without any timeout specified
+				Config: testAccDbtCloudJobResourceTimeoutConfig(
+					jobName,
+					projectName,
+					environmentName,
+					"none",
+					0, // ignored when mode is "none"
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "name", jobName),
+					// Default should be 0 (no timeout)
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "timeout_seconds", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDbtCloudJobResourceTimeoutConfig(
+	jobName, projectName, environmentName, mode string,
+	timeoutSeconds int,
+) string {
+	var timeoutConfig string
+
+	switch mode {
+	case "deprecated":
+		// Use deprecated top-level timeout_seconds
+		timeoutConfig = fmt.Sprintf("timeout_seconds = %d", timeoutSeconds)
+	case "execution":
+		// Use new execution attribute (SingleNestedAttribute uses = syntax, not block syntax)
+		timeoutConfig = fmt.Sprintf(`
+  execution = {
+    timeout_seconds = %d
+  }`, timeoutSeconds)
+	case "none":
+		// No timeout specified - use defaults
+		timeoutConfig = ""
+	default:
+		panic("Invalid mode: " + mode)
+	}
+
+	return fmt.Sprintf(`
+resource "dbtcloud_project" "test_job_project" {
+    name = "%s"
+}
+
+resource "dbtcloud_environment" "test_job_environment" {
+    project_id = dbtcloud_project.test_job_project.id
+    name = "%s"
+    dbt_version = "%s"
+    type = "development"
+}
+
+resource "dbtcloud_job" "test_job" {
+  name        = "%s"
+  project_id = dbtcloud_project.test_job_project.id
+  environment_id = dbtcloud_environment.test_job_environment.environment_id
+  execute_steps = [
+    "dbt test"
+  ]
+  triggers = {
+    "github_webhook": false,
+    "git_provider_webhook": false,
+    "schedule": false,
+  }
+  %s
+}
+`, projectName, environmentName, acctest_config.DBT_CLOUD_VERSION, jobName, timeoutConfig)
+}
+
+func testAccDbtCloudJobResourceTimeoutBothConfig(
+	jobName, projectName, environmentName string,
+	deprecatedTimeout, executionTimeout int,
+) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_project" "test_job_project" {
+    name = "%s"
+}
+
+resource "dbtcloud_environment" "test_job_environment" {
+    project_id = dbtcloud_project.test_job_project.id
+    name = "%s"
+    dbt_version = "%s"
+    type = "development"
+}
+
+resource "dbtcloud_job" "test_job" {
+  name        = "%s"
+  project_id = dbtcloud_project.test_job_project.id
+  environment_id = dbtcloud_environment.test_job_environment.environment_id
+  execute_steps = [
+    "dbt test"
+  ]
+  triggers = {
+    "github_webhook": false,
+    "git_provider_webhook": false,
+    "schedule": false,
+  }
+  timeout_seconds = %d
+  execution = {
+    timeout_seconds = %d
+  }
+}
+`, projectName, environmentName, acctest_config.DBT_CLOUD_VERSION, jobName, deprecatedTimeout, executionTimeout)
+}

--- a/pkg/framework/objects/job/schema.go
+++ b/pkg/framework/objects/job/schema.go
@@ -334,24 +334,24 @@ func (j *jobResource) Schema(
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
-			// "execution": resource_schema.SingleNestedAttribute{
-			// 	Optional: true,
-			// 	Computed: true,
-			// 	Attributes: map[string]resource_schema.Attribute{
-			// 		"timeout_seconds": resource_schema.Int64Attribute{
-			// 			Optional:    true,
-			// 			Computed:    true,
-			// 			Default:     int64default.StaticInt64(0),
-			// 			Description: "The number of seconds before the job times out",
-			// 		},
-			// 	},
-			// },
+			"execution": resource_schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Execution settings for the job",
+				Attributes: map[string]resource_schema.Attribute{
+					"timeout_seconds": resource_schema.Int64Attribute{
+						Optional:    true,
+						Computed:    true,
+						Default:     int64default.StaticInt64(0),
+						Description: "The number of seconds before the job times out",
+					},
+				},
+			},
 			"timeout_seconds": resource_schema.Int64Attribute{
 				Optional:           true,
 				Computed:           true,
 				Default:            int64default.StaticInt64(0),
-				DeprecationMessage: "Moved to execution.timeout_seconds",
-				Description:        "[Deprectated - Moved to execution.timeout_seconds] Number of seconds to allow the job to run before timing out",
+				DeprecationMessage: "Use execution.timeout_seconds instead",
+				Description:        "Number of seconds to allow the job to run before timing out. Use execution.timeout_seconds instead.",
 			},
 			"generate_docs": resource_schema.BoolAttribute{
 				Optional:    true,


### PR DESCRIPTION
This PR fixes the issue where `timeout_seconds` was marked as deprecated with "Moved to execution.timeout_seconds" but the execution block was never implemented.

**Changes**:
- Added execution block with timeout_seconds attribute to the job resource
- Marked top-level timeout_seconds as deprecated with proper migration guidance
- Full backward compatibility: existing configs using timeout_seconds continue to work
- When both are set, execution.timeout_seconds takes precedence

Closes #596