### PR TITLE
Fix permission duplication in partial_permissions resources

### DIFF
--- a/.changes/unreleased/Fixes-20260121-040352.yaml
+++ b/.changes/unreleased/Fixes-20260121-040352.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fix permission duplication in `dbtcloud_scim_group_partial_permissions` and `dbtcloud_group_partial_permissions` resources. Permissions could duplicate exponentially when multiple resources manage the same group or during repeated create/destroy cycles. The fix prevents new duplicates and automatically cleans up existing ones.
+time: 2026-01-21T04:03:52.000000+00:00

--- a/pkg/framework/objects/scim_group_partial_permissions/resource_unit_test.go
+++ b/pkg/framework/objects/scim_group_partial_permissions/resource_unit_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/objects/scim_group_partial_permissions"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -221,5 +222,173 @@ func TestConvertScimGroupPartialPermissionModelToData_SendsEmptyArray(t *testing
 	}
 	if len(apiPermissions[0].WritableEnvironmentCategories) != 0 {
 		t.Errorf("Expected writable_environment_categories to be empty, got %d elements", len(apiPermissions[0].WritableEnvironmentCategories))
+	}
+}
+
+// TestUnionByDeduplicatesPermissions tests that UnionBy correctly deduplicates
+// permissions when combining remote and new permissions during Create operations.
+// This is a regression test for the permission duplication bug.
+func TestUnionByDeduplicatesPermissions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Simulate remote permissions that already exist (e.g., from another resource or manual creation)
+	remotePermissions := []scim_group_partial_permissions.ScimGroupPartialPermissionModel{
+		{
+			PermissionSet: types.StringValue("account_admin"),
+			ProjectID:     types.Int64Null(),
+			AllProjects:   types.BoolValue(true),
+			WritableEnvironmentCategories: types.SetNull(types.StringType),
+		},
+		{
+			PermissionSet: types.StringValue("member"),
+			ProjectID:     types.Int64Null(),
+			AllProjects:   types.BoolValue(true),
+			WritableEnvironmentCategories: types.SetNull(types.StringType),
+		},
+	}
+
+	// Simulate new permissions that this resource wants to add
+	// Note: member already exists in remote, but we're trying to add it again
+	missingPermissions := []scim_group_partial_permissions.ScimGroupPartialPermissionModel{
+		{
+			PermissionSet: types.StringValue("member"), // Duplicate!
+			ProjectID:     types.Int64Null(),
+			AllProjects:   types.BoolValue(true),
+			WritableEnvironmentCategories: types.SetNull(types.StringType),
+		},
+		{
+			PermissionSet: types.StringValue("developer"),
+			ProjectID:     types.Int64Value(123),
+			AllProjects:   types.BoolValue(false),
+			WritableEnvironmentCategories: func() types.Set {
+				set, _ := types.SetValueFrom(ctx, types.StringType, []string{"development"})
+				return set
+			}(),
+		},
+	}
+
+	// Use UnionBy to combine (this is what the fixed Create function does)
+	result := helper.UnionBy(
+		remotePermissions,
+		missingPermissions,
+		scim_group_partial_permissions.CompareScimGroupPartialPermissions,
+	)
+
+	// Should have 3 unique permissions (account_admin, member, developer)
+	// NOT 4 (which would indicate member was duplicated)
+	if len(result) != 3 {
+		t.Errorf("Expected 3 deduplicated permissions, got %d", len(result))
+	}
+
+	// Verify we have exactly one of each
+	permissionSets := make(map[string]int)
+	for _, perm := range result {
+		permissionSets[perm.PermissionSet.ValueString()]++
+	}
+
+	expectedCounts := map[string]int{
+		"account_admin": 1,
+		"member":        1,
+		"developer":     1,
+	}
+
+	for permSet, expectedCount := range expectedCounts {
+		if count, ok := permissionSets[permSet]; !ok {
+			t.Errorf("Missing permission_set %s", permSet)
+		} else if count != expectedCount {
+			t.Errorf("Permission %s appeared %d times, expected %d", permSet, count, expectedCount)
+		}
+	}
+}
+
+// TestUnionByHandlesConcurrentResourceCreation tests the scenario where
+// multiple resources manage the same group and create near-simultaneously.
+// This simulates the federated permission management pattern.
+func TestUnionByHandlesConcurrentResourceCreation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Initial state: One pre-existing permission (e.g., manually added)
+	initialRemote := []scim_group_partial_permissions.ScimGroupPartialPermissionModel{
+		{
+			PermissionSet: types.StringValue("account_admin"),
+			ProjectID:     types.Int64Null(),
+			AllProjects:   types.BoolValue(true),
+			WritableEnvironmentCategories: types.SetNull(types.StringType),
+		},
+	}
+
+	// Resource A wants to add "member"
+	resourceAMissing := []scim_group_partial_permissions.ScimGroupPartialPermissionModel{
+		{
+			PermissionSet: types.StringValue("member"),
+			ProjectID:     types.Int64Null(),
+			AllProjects:   types.BoolValue(true),
+			WritableEnvironmentCategories: types.SetNull(types.StringType),
+		},
+	}
+
+	// Resource B wants to add "developer" (reads same initial state due to timing)
+	resourceBMissing := []scim_group_partial_permissions.ScimGroupPartialPermissionModel{
+		{
+			PermissionSet: types.StringValue("developer"),
+			ProjectID:     types.Int64Value(123),
+			AllProjects:   types.BoolValue(false),
+			WritableEnvironmentCategories: func() types.Set {
+				set, _ := types.SetValueFrom(ctx, types.StringType, []string{"development"})
+				return set
+			}(),
+		},
+	}
+
+	// Resource A combines with UnionBy
+	resourceAResult := helper.UnionBy(
+		initialRemote,
+		resourceAMissing,
+		scim_group_partial_permissions.CompareScimGroupPartialPermissions,
+	)
+
+	// Resource B combines with UnionBy (still sees initial remote)
+	resourceBResult := helper.UnionBy(
+		initialRemote,
+		resourceBMissing,
+		scim_group_partial_permissions.CompareScimGroupPartialPermissions,
+	)
+
+	// Both should have account_admin + their respective permission
+	if len(resourceAResult) != 2 {
+		t.Errorf("Resource A: expected 2 permissions, got %d", len(resourceAResult))
+	}
+	if len(resourceBResult) != 2 {
+		t.Errorf("Resource B: expected 2 permissions, got %d", len(resourceBResult))
+	}
+
+	// Simulate what happens when Resource B runs after Resource A completes
+	// Resource B should read the updated remote state and combine properly
+	updatedRemote := resourceAResult // Now includes account_admin + member
+	resourceBFinal := helper.UnionBy(
+		updatedRemote,
+		resourceBMissing,
+		scim_group_partial_permissions.CompareScimGroupPartialPermissions,
+	)
+
+	// Should have all 3 permissions with no duplicates
+	if len(resourceBFinal) != 3 {
+		t.Errorf("Final state: expected 3 permissions, got %d", len(resourceBFinal))
+	}
+
+	permissionSets := make(map[string]int)
+	for _, perm := range resourceBFinal {
+		permissionSets[perm.PermissionSet.ValueString()]++
+	}
+
+	// Verify no duplicates
+	for permSet, count := range permissionSets {
+		if count != 1 {
+			t.Errorf("Permission %s appeared %d times, expected 1 (duplicate detected!)", permSet, count)
+		}
 	}
 }

--- a/pkg/helper/lo.go
+++ b/pkg/helper/lo.go
@@ -86,3 +86,27 @@ func UnionBy[T any](
 
 	return response
 }
+
+// UniqBy removes duplicates from a slice based on a predicate function.
+// This is useful for deduplicating slices where simple equality doesn't work.
+func UniqBy[T any](
+	list []T,
+	predicate func(T, T) bool,
+) []T {
+	result := []T{}
+
+	for _, item := range list {
+		found := false
+		for _, uniqueItem := range result {
+			if predicate(item, uniqueItem) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			result = append(result, item)
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
Proposed resolution to #610 

- Replace append() with UnionBy() in Create to prevent new duplicates
- Add UniqBy() deduplication after reading remote permissions for self-healing
- Add UniqBy() helper function to deduplicate slices with custom comparison
- Add unit tests for deduplication logic
- Add changie entry

Fixes issue where permissions could duplicate exponentially when multiple resources manage the same group or during repeated create/destroy cycles. The fix is self-healing and will automatically clean up existing duplicates.