### PR TITLE
Only check deployment_env_auth_type when latest adapter is used

### DIFF
--- a/.changes/unreleased/Fixes-20260121-105634.yaml
+++ b/.changes/unreleased/Fixes-20260121-105634.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Only check deployment_env_auth_type when latest adapter is used
+time: 2026-01-21T10:56:34.48595+02:00

--- a/pkg/framework/objects/global_connection/resource.go
+++ b/pkg/framework/objects/global_connection/resource.go
@@ -251,7 +251,9 @@ func (r *globalConnectionResource) Create(
 				plan.BigQueryConfig.DataprocClusterName.ValueString(),
 			)
 		}
-		if !plan.BigQueryConfig.DeploymentEnvAuthType.IsNull() {
+		// Only send deployment_env_auth_type for v1 adapter (use_latest_adapter = true)
+		// The v0 (legacy) adapter does not support this field - fixes GitHub issue #612
+		if plan.BigQueryConfig.UseLatestAdapter.ValueBool() && !plan.BigQueryConfig.DeploymentEnvAuthType.IsNull() {
 			bigqueryCfg.DeploymentEnvAuthType.Set(
 				plan.BigQueryConfig.DeploymentEnvAuthType.ValueString(),
 			)
@@ -976,13 +978,17 @@ func (r *globalConnectionResource) Update(
 				)
 			}
 		}
-		if plan.BigQueryConfig.DeploymentEnvAuthType != state.BigQueryConfig.DeploymentEnvAuthType {
-			if plan.BigQueryConfig.DeploymentEnvAuthType.IsNull() {
-				warehouseConfigChanges.DeploymentEnvAuthType.SetNull()
-			} else {
-				warehouseConfigChanges.DeploymentEnvAuthType.Set(
-					plan.BigQueryConfig.DeploymentEnvAuthType.ValueString(),
-				)
+		// Only send deployment_env_auth_type for v1 adapter (use_latest_adapter = true)
+		// The v0 (legacy) adapter does not support this field - fixes GitHub issue #612
+		if plan.BigQueryConfig.UseLatestAdapter.ValueBool() {
+			if plan.BigQueryConfig.DeploymentEnvAuthType != state.BigQueryConfig.DeploymentEnvAuthType {
+				if plan.BigQueryConfig.DeploymentEnvAuthType.IsNull() {
+					warehouseConfigChanges.DeploymentEnvAuthType.SetNull()
+				} else {
+					warehouseConfigChanges.DeploymentEnvAuthType.Set(
+						plan.BigQueryConfig.DeploymentEnvAuthType.ValueString(),
+					)
+				}
 			}
 		}
 


### PR DESCRIPTION
**Problem**:
BigQuery connections using the legacy v0 adapter fail when updated after upgrading to provider v1.5.2+. The API returns:
"BigqueryConnection" object has no field "`deployment_env_auth_type`"

**Root Cause:**
The `deployment_env_auth_type` field was added in v1.5.2 with a schema default of "service-account-json". This caused the provider to send this field to the API for all BigQuery connections, but the v0 (legacy) adapter does not support it.

**Fix**:
Only send `deployment_env_auth_type` when use_latest_adapter = true (v1 adapter). The v0 adapter now correctly omits this field.

Fixes #612