### PR TITLE
Fix failing e2e tests

### DIFF
--- a/.changes/unreleased/Fixes-20260213-091141.yaml
+++ b/.changes/unreleased/Fixes-20260213-091141.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fix failing e2e tests
+time: 2026-02-13T09:11:41.923068+02:00

--- a/pkg/dbt_cloud/salesforce_credential.go
+++ b/pkg/dbt_cloud/salesforce_credential.go
@@ -27,7 +27,7 @@ type SalesforceUnencryptedCredentialDetails struct {
 
 type SalesforceCredential struct {
 	ID                           *int                                   `json:"id"`
-	Account_Id                   int                                    `json:"account_id"`
+	Account_Id                   int64                                  `json:"account_id"`
 	Project_Id                   int                                    `json:"project_id"`
 	Type                         string                                 `json:"type"`
 	State                        int                                    `json:"state"`
@@ -40,7 +40,7 @@ type SalesforceCredential struct {
 
 type SalesforceCredentialGlobConn struct {
 	ID                *int                     `json:"id"`
-	AccountID         int                      `json:"account_id"`
+	AccountID         int64                    `json:"account_id"`
 	ProjectID         int                      `json:"project_id"`
 	Type              string                   `json:"type"`
 	State             int                      `json:"state"`


### PR DESCRIPTION
The salesforce credential used an account_id of type int instead of int64, causing daily and e2e tests to fail.