### PR TITLE
fix: remove connection_id default of 0 in dbtcloud_environment (closes #665)

### DIFF
--- a/.changes/unreleased/Fixes-20260409-195804.yaml
+++ b/.changes/unreleased/Fixes-20260409-195804.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Remove `connection_id` default of `0` in `dbtcloud_environment` to prevent "inconsistent result after apply" when the API auto-assigns a connection
+time: 2026-04-09T19:58:04.000000+00:00

--- a/pkg/framework/objects/environment/resource.go
+++ b/pkg/framework/objects/environment/resource.go
@@ -19,6 +19,15 @@ var (
 	_ resource.ResourceWithImportState = &environmentResource{}
 )
 
+// connectionIDFromAPI converts the API connection_id pointer to a types.Int64 value,
+// treating nil and 0 as "not set" (null) so Terraform doesn't see a spurious diff.
+func connectionIDFromAPI(id *int) types.Int64 {
+	if id != nil && *id != 0 {
+		return types.Int64Value(int64(*id))
+	}
+	return types.Int64Null()
+}
+
 func EnvironmentResource() resource.Resource {
 	return &environmentResource{}
 }
@@ -81,11 +90,7 @@ func (r *environmentResource) Read(
 		state.ExtendedAttributesID = types.Int64Null()
 	}
 	state.EnableModelQueryHistory = types.BoolValue(environment.EnableModelQueryHistory)
-	if environment.ConnectionID != nil {
-		state.ConnectionID = types.Int64Value(int64(*environment.ConnectionID))
-	} else {
-		state.ConnectionID = types.Int64Value(0)
-	}
+	state.ConnectionID = connectionIDFromAPI(environment.ConnectionID)
 	if environment.Credential_Id != nil {
 		state.CredentialID = types.Int64Value(int64(*environment.Credential_Id))
 	} else {
@@ -185,11 +190,7 @@ func (r *environmentResource) Create(
 		plan.ExtendedAttributesID = types.Int64Null()
 	}
 	plan.EnableModelQueryHistory = types.BoolValue(environment.EnableModelQueryHistory)
-	if environment.ConnectionID != nil {
-		plan.ConnectionID = types.Int64Value(int64(*environment.ConnectionID))
-	} else {
-		plan.ConnectionID = types.Int64Value(0)
-	}
+	plan.ConnectionID = connectionIDFromAPI(environment.ConnectionID)
 	plan.CredentialID = types.Int64PointerValue(
 		helper.IntPointerToInt64Pointer(environment.Credential_Id),
 	)
@@ -329,11 +330,7 @@ func (r *environmentResource) Update(
 	}
 
 	plan.EnvironmentID = types.Int64Value(int64(*updatedEnv.Environment_Id))
-	if updatedEnv.ConnectionID != nil {
-		plan.ConnectionID = types.Int64Value(int64(*updatedEnv.ConnectionID))
-	} else {
-		plan.ConnectionID = types.Int64Value(0)
-	}
+	plan.ConnectionID = connectionIDFromAPI(updatedEnv.ConnectionID)
 	if updatedEnv.Credential_Id != nil {
 		plan.CredentialID = types.Int64Value(int64(*updatedEnv.Credential_Id))
 	} else {
@@ -435,8 +432,8 @@ func (r *environmentResource) ImportState(
 		return
 	}
 
-	// Set connection_id to 0 to match the test's expectation
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connection_id"), types.Int64Value(0))...)
+	// Set connection_id to null so it is refreshed from the API on the next plan/apply
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connection_id"), types.Int64Null())...)
 }
 
 func (r *environmentResource) Configure(

--- a/pkg/framework/objects/environment/resource_acceptance_test.go
+++ b/pkg/framework/objects/environment/resource_acceptance_test.go
@@ -70,10 +70,9 @@ func getBasicConfigWithModifiedConfigTestStep(projectName, environmentName, cust
 				"deployment_type",
 				"production",
 			),
-			resource.TestCheckResourceAttr(
+			resource.TestCheckNoResourceAttr(
 				"dbtcloud_environment.test_env",
 				"connection_id",
-				"0",
 			),
 		),
 	}

--- a/pkg/framework/objects/environment/schema.go
+++ b/pkg/framework/objects/environment/schema.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -263,7 +262,6 @@ func (r *environmentResource) Schema(
 			"connection_id": resource_schema.Int64Attribute{
 				Optional:    true,
 				Computed:    true,
-				Default:     int64default.StaticInt64(0),
 				Description: "A connection ID (used with Global Connections)",
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),


### PR DESCRIPTION
## Summary
- Removes `Default: int64default.StaticInt64(0)` from `connection_id` in `dbtcloud_environment` schema
- Adds `connectionIDFromAPI(*int) types.Int64` helper that maps both `nil` and `0` from the API to `types.Int64Null()` in Terraform state
- Fixes Create, Update, and Read methods to use null-safe handling for `connection_id`

Prevents the "inconsistent result after apply" error that occurs when the dbt Cloud API auto-assigns a non-zero connection ID after create.

Closes #665

🤖 Generated with [Claude Code](https://claude.ai/claude-code)