### PR TITLE
fix: refine dbtcloud_job type transition rules to avoid unnecessary replacement (closes #666)

### DIFF
--- a/.changes/unreleased/Fixes-20260409-195805.yaml
+++ b/.changes/unreleased/Fixes-20260409-195805.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Narrow `dbtcloud_job` type transition replacement rules — only CI↔non-CI and Adaptive↔non-Adaptive transitions now force resource replacement
+time: 2026-04-09T19:58:05.000000+00:00

--- a/pkg/framework/objects/job/resource.go
+++ b/pkg/framework/objects/job/resource.go
@@ -36,44 +36,40 @@ type jobResource struct {
 	client *dbt_cloud.Client
 }
 
-// validateJobTypeChange validates if a job type transition is allowed.
-// This mirrors the server-side validation in _validate_job_type_change.
+// requiresJobTypeReplacement reports whether changing from oldType to newType
+// requires the resource to be destroyed and recreated.
+// Only transitions involving CI or Adaptive require replacement; all other
+// transitions (scheduled <-> other <-> merge) can be performed in-place.
+func requiresJobTypeReplacement(oldType, newType string) bool {
+	if oldType == newType {
+		return false
+	}
+	if oldType == JobTypeCI || newType == JobTypeCI {
+		return true
+	}
+	if oldType == JobTypeAdaptive || newType == JobTypeAdaptive {
+		return true
+	}
+	return false
+}
+
+// validateJobTypeChange returns an error if the in-place job_type transition is
+// not permitted by the API. CI and Adaptive transitions are handled upstream by
+// requiresJobTypeReplacement (forced replace); this function guards the remaining
+// invalid combinations as a safety net.
 func validateJobTypeChange(prevJobType, newJobType string) error {
-	// If no change, always allowed
-	if prevJobType == newJobType {
+	if prevJobType == newJobType || prevJobType == "" {
 		return nil
 	}
-
-	// If previous type is empty (not set), any new type is allowed
-	if prevJobType == "" {
-		return nil
-	}
-
-	// CI jobs can only stay CI
 	if prevJobType == JobTypeCI && newJobType != JobTypeCI {
 		return fmt.Errorf("the job type field for this job can only be set to 'ci'")
 	}
-
-	// Adaptive jobs can only stay adaptive
 	if prevJobType == JobTypeAdaptive && newJobType != JobTypeAdaptive {
 		return fmt.Errorf("the job type field for this job can only be set to 'adaptive'")
 	}
-
-	// Scheduled jobs can only change to scheduled or other
-	if prevJobType == JobTypeScheduled && (newJobType == JobTypeCI || newJobType == JobTypeAdaptive) {
-		return fmt.Errorf("the job type field for this job can only be set to 'scheduled' or 'other'")
+	if newJobType == JobTypeCI || newJobType == JobTypeAdaptive {
+		return fmt.Errorf("cannot change job_type to '%s' from '%s'", newJobType, prevJobType)
 	}
-
-	// Other jobs can only change to scheduled or other
-	if prevJobType == JobTypeOther && (newJobType == JobTypeCI || newJobType == JobTypeAdaptive) {
-		return fmt.Errorf("the job type field for this job can only be set to 'scheduled' or 'other'")
-	}
-
-	// Merge jobs - treating similar to CI (cannot change away from merge)
-	if prevJobType == JobTypeMerge && newJobType != JobTypeMerge {
-		return fmt.Errorf("the job type field for this job can only be set to 'merge'")
-	}
-
 	return nil
 }
 
@@ -108,50 +104,40 @@ func (j *jobResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 		return
 	}
 
-	// Skip checks if necessary fields are null
 	if plan.Triggers == nil || state.Triggers == nil {
 		return
 	}
 
-	// if we change the job type (CI, merge or "empty"), we need to recreate the job as dbt Cloud doesn't allow updating them
-	// the job type is determined by the triggers
-	if plan.Triggers != nil && state.Triggers != nil {
-		oldCI := state.Triggers.GithubWebhook.ValueBool() || state.Triggers.GitProviderWebhook.ValueBool()
-		oldOnMerge := state.Triggers.OnMerge.ValueBool()
-
-		oldType := ""
-		if oldCI {
-			oldType = "ci"
-		} else if oldOnMerge {
-			oldType = "merge"
-		}
-
-		newCI := plan.Triggers.GithubWebhook.ValueBool() || plan.Triggers.GitProviderWebhook.ValueBool()
-		newOnMerge := plan.Triggers.OnMerge.ValueBool()
-
-		newType := ""
-		if newCI {
-			newType = "ci"
-		} else if newOnMerge {
-			newType = "merge"
-		}
-
-		if oldType != newType {
-			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("triggers"))
-		}
+	oldCI := state.Triggers.GithubWebhook.ValueBool() || state.Triggers.GitProviderWebhook.ValueBool()
+	oldOnMerge := state.Triggers.OnMerge.ValueBool()
+	oldType := JobTypeOther
+	if oldCI {
+		oldType = JobTypeCI
+	} else if oldOnMerge {
+		oldType = JobTypeMerge
 	}
 
-	// Validate job_type field changes if the field is being explicitly set
-	// Note: If plan.JobType is set but state.JobType is null (first time setting it),
-	// the validation will happen in Update against the actual server value
-	// Skip validation if either value is empty (empty means "not explicitly set")
+	newCI := plan.Triggers.GithubWebhook.ValueBool() || plan.Triggers.GitProviderWebhook.ValueBool()
+	newOnMerge := plan.Triggers.OnMerge.ValueBool()
+	newType := JobTypeOther
+	if newCI {
+		newType = JobTypeCI
+	} else if newOnMerge {
+		newType = JobTypeMerge
+	}
+
+	if requiresJobTypeReplacement(oldType, newType) {
+		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("triggers"))
+	}
+
 	if !plan.JobType.IsNull() && !state.JobType.IsNull() {
 		prevJobType := state.JobType.ValueString()
 		newJobType := plan.JobType.ValueString()
 
-		// Only validate if both values are non-empty (explicitly set)
-		if prevJobType != "" && newJobType != "" {
-			if err := validateJobTypeChange(prevJobType, newJobType); err != nil {
+		if prevJobType != "" && newJobType != "" && prevJobType != newJobType {
+			if requiresJobTypeReplacement(prevJobType, newJobType) {
+				resp.RequiresReplace = append(resp.RequiresReplace, path.Root("job_type"))
+			} else if err := validateJobTypeChange(prevJobType, newJobType); err != nil {
 				resp.Diagnostics.AddError(
 					"Invalid job_type change",
 					fmt.Sprintf("Cannot change job_type from '%s' to '%s': %s", prevJobType, newJobType, err.Error()),

--- a/pkg/framework/objects/job/resource_acceptance_job_type_test.go
+++ b/pkg/framework/objects/job/resource_acceptance_job_type_test.go
@@ -120,23 +120,30 @@ func TestValidateJobTypeChange(t *testing.T) {
 			errorSubstr: "can only be set to 'adaptive'",
 		},
 
-		// Merge job type transitions - only merge allowed
+		// Merge job type transitions - merge, scheduled, and other are all allowed in-place;
+		// transitions to CI or Adaptive are blocked (those would require replacement at the
+		// ModifyPlan level but validateJobTypeChange still guards them).
 		{
 			name:        "merge to ci - not allowed",
 			prevType:    JobTypeMerge,
 			newType:     JobTypeCI,
 			expectError: true,
-			errorSubstr: "can only be set to 'merge'",
+			errorSubstr: "cannot change job_type to 'ci'",
 		},
 		{
-			name:        "merge to scheduled - not allowed",
+			name:        "merge to scheduled - allowed in-place",
 			prevType:    JobTypeMerge,
 			newType:     JobTypeScheduled,
-			expectError: true,
-			errorSubstr: "can only be set to 'merge'",
+			expectError: false,
+		},
+		{
+			name:        "merge to other - allowed in-place",
+			prevType:    JobTypeMerge,
+			newType:     JobTypeOther,
+			expectError: false,
 		},
 
-		// Scheduled job type transitions - scheduled or other allowed
+		// Scheduled job type transitions - scheduled, other, and merge are all allowed in-place
 		{
 			name:        "scheduled to other - allowed",
 			prevType:    JobTypeScheduled,
@@ -144,21 +151,27 @@ func TestValidateJobTypeChange(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "scheduled to merge - allowed in-place",
+			prevType:    JobTypeScheduled,
+			newType:     JobTypeMerge,
+			expectError: false,
+		},
+		{
 			name:        "scheduled to ci - not allowed",
 			prevType:    JobTypeScheduled,
 			newType:     JobTypeCI,
 			expectError: true,
-			errorSubstr: "can only be set to 'scheduled' or 'other'",
+			errorSubstr: "cannot change job_type to 'ci'",
 		},
 		{
 			name:        "scheduled to adaptive - not allowed",
 			prevType:    JobTypeScheduled,
 			newType:     JobTypeAdaptive,
 			expectError: true,
-			errorSubstr: "can only be set to 'scheduled' or 'other'",
+			errorSubstr: "cannot change job_type to 'adaptive'",
 		},
 
-		// Other job type transitions - scheduled or other allowed
+		// Other job type transitions - scheduled, other, and merge are all allowed in-place
 		{
 			name:        "other to scheduled - allowed",
 			prevType:    JobTypeOther,
@@ -166,18 +179,24 @@ func TestValidateJobTypeChange(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "other to merge - allowed in-place",
+			prevType:    JobTypeOther,
+			newType:     JobTypeMerge,
+			expectError: false,
+		},
+		{
 			name:        "other to ci - not allowed",
 			prevType:    JobTypeOther,
 			newType:     JobTypeCI,
 			expectError: true,
-			errorSubstr: "can only be set to 'scheduled' or 'other'",
+			errorSubstr: "cannot change job_type to 'ci'",
 		},
 		{
 			name:        "other to adaptive - not allowed",
 			prevType:    JobTypeOther,
 			newType:     JobTypeAdaptive,
 			expectError: true,
-			errorSubstr: "can only be set to 'scheduled' or 'other'",
+			errorSubstr: "cannot change job_type to 'adaptive'",
 		},
 	}
 
@@ -228,20 +247,20 @@ func TestValidateJobTypeChange_AllTransitions(t *testing.T) {
 		JobTypeMerge: {
 			JobTypeCI:        false,
 			JobTypeMerge:     true,
-			JobTypeScheduled: false,
-			JobTypeOther:     false,
+			JobTypeScheduled: true, // in-place transition allowed
+			JobTypeOther:     true, // in-place transition allowed
 			JobTypeAdaptive:  false,
 		},
 		JobTypeScheduled: {
 			JobTypeCI:        false,
-			JobTypeMerge:     true, // merge is allowed from scheduled (not in original server code but reasonable)
+			JobTypeMerge:     true, // in-place transition allowed
 			JobTypeScheduled: true,
 			JobTypeOther:     true,
 			JobTypeAdaptive:  false,
 		},
 		JobTypeOther: {
 			JobTypeCI:        false,
-			JobTypeMerge:     true, // merge is allowed from other (not in original server code but reasonable)
+			JobTypeMerge:     true, // in-place transition allowed
 			JobTypeScheduled: true,
 			JobTypeOther:     true,
 			JobTypeAdaptive:  false,
@@ -303,5 +322,59 @@ func TestJobTypeConstants(t *testing.T) {
 		if tc.constant != tc.expected {
 			t.Errorf("expected constant to be %q, got %q", tc.expected, tc.constant)
 		}
+	}
+}
+
+func TestRequiresJobTypeReplacement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		oldType  string
+		newType  string
+		expected bool
+	}{
+		// Same type — never requires replacement
+		{name: "ci to ci", oldType: JobTypeCI, newType: JobTypeCI, expected: false},
+		{name: "scheduled to scheduled", oldType: JobTypeScheduled, newType: JobTypeScheduled, expected: false},
+		{name: "other to other", oldType: JobTypeOther, newType: JobTypeOther, expected: false},
+		{name: "merge to merge", oldType: JobTypeMerge, newType: JobTypeMerge, expected: false},
+		{name: "adaptive to adaptive", oldType: JobTypeAdaptive, newType: JobTypeAdaptive, expected: false},
+
+		// CI transitions — always require replacement
+		{name: "ci to scheduled", oldType: JobTypeCI, newType: JobTypeScheduled, expected: true},
+		{name: "ci to other", oldType: JobTypeCI, newType: JobTypeOther, expected: true},
+		{name: "ci to merge", oldType: JobTypeCI, newType: JobTypeMerge, expected: true},
+		{name: "ci to adaptive", oldType: JobTypeCI, newType: JobTypeAdaptive, expected: true},
+		{name: "scheduled to ci", oldType: JobTypeScheduled, newType: JobTypeCI, expected: true},
+		{name: "other to ci", oldType: JobTypeOther, newType: JobTypeCI, expected: true},
+		{name: "merge to ci", oldType: JobTypeMerge, newType: JobTypeCI, expected: true},
+
+		// Adaptive transitions — always require replacement
+		{name: "adaptive to scheduled", oldType: JobTypeAdaptive, newType: JobTypeScheduled, expected: true},
+		{name: "adaptive to other", oldType: JobTypeAdaptive, newType: JobTypeOther, expected: true},
+		{name: "adaptive to merge", oldType: JobTypeAdaptive, newType: JobTypeMerge, expected: true},
+		{name: "scheduled to adaptive", oldType: JobTypeScheduled, newType: JobTypeAdaptive, expected: true},
+		{name: "other to adaptive", oldType: JobTypeOther, newType: JobTypeAdaptive, expected: true},
+		{name: "merge to adaptive", oldType: JobTypeMerge, newType: JobTypeAdaptive, expected: true},
+
+		// In-place transitions (scheduled / other / merge)
+		{name: "scheduled to other", oldType: JobTypeScheduled, newType: JobTypeOther, expected: false},
+		{name: "scheduled to merge", oldType: JobTypeScheduled, newType: JobTypeMerge, expected: false},
+		{name: "other to scheduled", oldType: JobTypeOther, newType: JobTypeScheduled, expected: false},
+		{name: "other to merge", oldType: JobTypeOther, newType: JobTypeMerge, expected: false},
+		{name: "merge to scheduled", oldType: JobTypeMerge, newType: JobTypeScheduled, expected: false},
+		{name: "merge to other", oldType: JobTypeMerge, newType: JobTypeOther, expected: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := requiresJobTypeReplacement(tc.oldType, tc.newType)
+			if got != tc.expected {
+				t.Errorf("requiresJobTypeReplacement(%q, %q) = %v, want %v", tc.oldType, tc.newType, got, tc.expected)
+			}
+		})
 	}
 }

--- a/pkg/framework/objects/job/resource_acceptance_test.go
+++ b/pkg/framework/objects/job/resource_acceptance_test.go
@@ -981,3 +981,184 @@ resource "dbtcloud_job" "test_job" {
 }
 `, projectName, environmentName, acctest_config.DBT_CLOUD_VERSION, jobName, interval, daysStr)
 }
+
+// TestAccDbtCloudJobResourceJobTypeInPlaceTransitions verifies that transitions
+// between scheduled, other, and merge do NOT require resource replacement.
+func TestAccDbtCloudJobResourceJobTypeInPlaceTransitions(t *testing.T) {
+	jobName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	var firstID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudJobDestroy,
+		Steps: []resource.TestStep{
+			// Create with job_type = "scheduled"
+			{
+				Config: testAccDbtCloudJobResourceJobTypeTransitionConfig(jobName, projectName, environmentName, "scheduled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "job_type", "scheduled"),
+					// Capture the resource ID for later comparison
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["dbtcloud_job.test_job"]
+						if !ok {
+							return fmt.Errorf("resource dbtcloud_job.test_job not found")
+						}
+						firstID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			// Transition scheduled -> other: must be in-place (same ID)
+			{
+				Config: testAccDbtCloudJobResourceJobTypeTransitionConfig(jobName, projectName, environmentName, "other"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "job_type", "other"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["dbtcloud_job.test_job"]
+						if !ok {
+							return fmt.Errorf("resource dbtcloud_job.test_job not found")
+						}
+						if rs.Primary.ID != firstID {
+							return fmt.Errorf("expected same resource ID after in-place job_type change (scheduled->other), got %s, want %s", rs.Primary.ID, firstID)
+						}
+						return nil
+					},
+				),
+			},
+			// Transition other -> merge: must be in-place (same ID)
+			{
+				Config: testAccDbtCloudJobResourceJobTypeTransitionConfig(jobName, projectName, environmentName, "merge"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "job_type", "merge"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["dbtcloud_job.test_job"]
+						if !ok {
+							return fmt.Errorf("resource dbtcloud_job.test_job not found")
+						}
+						if rs.Primary.ID != firstID {
+							return fmt.Errorf("expected same resource ID after in-place job_type change (other->merge), got %s, want %s", rs.Primary.ID, firstID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestAccDbtCloudJobResourceJobTypeCIRequiresReplacement verifies that a
+// transition from ci to scheduled forces resource replacement (new ID).
+func TestAccDbtCloudJobResourceJobTypeCIRequiresReplacement(t *testing.T) {
+	jobName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	projectName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	environmentName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	var ciID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudJobDestroy,
+		Steps: []resource.TestStep{
+			// Create with job_type = "ci"
+			{
+				Config: testAccDbtCloudJobResourceJobTypeCIConfig(jobName, projectName, environmentName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "job_type", "ci"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["dbtcloud_job.test_job"]
+						if !ok {
+							return fmt.Errorf("resource dbtcloud_job.test_job not found")
+						}
+						ciID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			// Transition ci -> scheduled: must create a new resource (different ID)
+			{
+				Config: testAccDbtCloudJobResourceJobTypeTransitionConfig(jobName, projectName, environmentName, "scheduled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbtCloudJobExists("dbtcloud_job.test_job"),
+					resource.TestCheckResourceAttr("dbtcloud_job.test_job", "job_type", "scheduled"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["dbtcloud_job.test_job"]
+						if !ok {
+							return fmt.Errorf("resource dbtcloud_job.test_job not found")
+						}
+						if rs.Primary.ID == ciID {
+							return fmt.Errorf("expected new resource ID after ci->scheduled job_type change (replacement required), but ID is unchanged: %s", ciID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccDbtCloudJobResourceJobTypeTransitionConfig(jobName, projectName, environmentName, jobType string) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_project" "test_job_project" {
+    name = "%s"
+}
+
+resource "dbtcloud_environment" "test_job_environment" {
+    project_id = dbtcloud_project.test_job_project.id
+    name       = "%s"
+    dbt_version = "%s"
+    type       = "deployment"
+}
+
+resource "dbtcloud_job" "test_job" {
+    name           = "%s"
+    project_id     = dbtcloud_project.test_job_project.id
+    environment_id = dbtcloud_environment.test_job_environment.environment_id
+    execute_steps  = ["dbt build"]
+    triggers = {
+        "github_webhook"      : false,
+        "git_provider_webhook": false,
+        "schedule"            : false,
+    }
+    job_type = "%s"
+}
+`, projectName, environmentName, acctest_config.DBT_CLOUD_VERSION, jobName, jobType)
+}
+
+func testAccDbtCloudJobResourceJobTypeCIConfig(jobName, projectName, environmentName string) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_project" "test_job_project" {
+    name = "%s"
+}
+
+resource "dbtcloud_environment" "test_job_environment" {
+    project_id = dbtcloud_project.test_job_project.id
+    name       = "%s"
+    dbt_version = "%s"
+    type       = "deployment"
+}
+
+resource "dbtcloud_job" "test_job" {
+    name                     = "%s"
+    project_id               = dbtcloud_project.test_job_project.id
+    environment_id           = dbtcloud_environment.test_job_environment.environment_id
+    deferring_environment_id = dbtcloud_environment.test_job_environment.environment_id
+    execute_steps            = ["dbt build"]
+    triggers = {
+        "github_webhook"      : false,
+        "git_provider_webhook": false,
+        "schedule"            : false,
+    }
+    job_type            = "ci"
+    run_compare_changes = true
+}
+`, projectName, environmentName, acctest_config.DBT_CLOUD_VERSION, jobName)
+}

--- a/pkg/framework/objects/job/resource_acceptance_test.go
+++ b/pkg/framework/objects/job/resource_acceptance_test.go
@@ -1106,6 +1106,15 @@ func TestAccDbtCloudJobResourceJobTypeCIRequiresReplacement(t *testing.T) {
 }
 
 func testAccDbtCloudJobResourceJobTypeTransitionConfig(jobName, projectName, environmentName, jobType string) string {
+	// The API infers job_type from triggers, so we must set matching triggers.
+	scheduleTrigger := "false"
+	onMergeTrigger := "false"
+	switch jobType {
+	case "scheduled":
+		scheduleTrigger = "true"
+	case "merge":
+		onMergeTrigger = "true"
+	}
 	return fmt.Sprintf(`
 resource "dbtcloud_project" "test_job_project" {
     name = "%s"
@@ -1126,11 +1135,12 @@ resource "dbtcloud_job" "test_job" {
     triggers = {
         "github_webhook"      : false,
         "git_provider_webhook": false,
-        "schedule"            : false,
+        "schedule"            : %s,
+        "on_merge"            : %s,
     }
     job_type = "%s"
 }
-`, projectName, environmentName, acctest_config.DBT_CLOUD_VERSION, jobName, jobType)
+`, projectName, environmentName, acctest_config.DBT_CLOUD_VERSION, jobName, scheduleTrigger, onMergeTrigger, jobType)
 }
 
 func testAccDbtCloudJobResourceJobTypeCIConfig(jobName, projectName, environmentName string) string {


### PR DESCRIPTION
## Summary
- Only CI↔non-CI and Adaptive↔non-Adaptive transitions now require resource replacement
- Scheduled↔Other and Merge↔Other/Scheduled transitions allow in-place updates
- Adds `requiresJobTypeReplacement()` helper function
- Adds two new acceptance test functions for valid in-place and replacement transitions

Closes #666

🤖 Generated with [Claude Code](https://claude.ai/claude-code)