### PR TITLE
feat: add resource_metadata field to all resources (closes #662)

### DIFF
--- a/.changes/unreleased/Changes-20260409-195800.yaml
+++ b/.changes/unreleased/Changes-20260409-195800.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: Add optional `resource_metadata` Dynamic field to all resource schemas and models for account migration tooling support
+time: 2026-04-09T19:58:00.000000+00:00

--- a/docs/data-sources/global_connection.md
+++ b/docs/data-sources/global_connection.md
@@ -25,6 +25,10 @@ data dbtcloud_global_connection my_connection {
 
 - `id` (Number) Connection Identifier
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `adapter_version` (String) Version of the adapter

--- a/docs/resources/account_features.md
+++ b/docs/resources/account_features.md
@@ -47,6 +47,7 @@ resource "dbtcloud_account_features" "my_features" {
 - `fusion_migration_permissions` (Boolean) Whether permissions for accounts migrating to Fusion are enabled.
 - `partial_parsing` (Boolean) Whether partial parsing is enabled.
 - `repo_caching` (Boolean) Whether repository caching is enabled.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/athena_credential.md
+++ b/docs/resources/athena_credential.md
@@ -61,6 +61,7 @@ resource "dbtcloud_athena_credential" "example_wo" {
 - `aws_secret_access_key` (String, Sensitive) AWS secret access key for Athena user. Consider using `aws_secret_access_key_wo` instead, which is not stored in state.
 - `aws_secret_access_key_wo` (String) Write-only alternative to `aws_secret_access_key`. The value is not stored in state. Requires `aws_secret_access_key_wo_version` to trigger updates.
 - `aws_secret_access_key_wo_version` (Number) Version number for `aws_secret_access_key_wo`. Increment this value to trigger an update of the AWS secret access key when using `aws_secret_access_key_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/auth_provider.md
+++ b/docs/resources/auth_provider.md
@@ -166,6 +166,7 @@ resource "dbtcloud_auth_provider" "gsuite" {
 - `gsuite_admin_id` (String) Google Workspace admin email used to fetch group memberships.
 - `include_indirect_groups` (Boolean) Whether to include transitive (indirect) group memberships from Azure AD. Defaults to true.
 - `max_groups_to_retrieve` (Number) Maximum number of Azure AD groups to fetch per user. Defaults to 250.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `sign_request` (Boolean) Whether to sign SAML authentication requests. Defaults to false.
 - `slug` (String) URL-safe identifier used in the SSO login URL. Auto-generated if omitted. Immutable on accounts where auto-slug enforcement is enabled.
 - `sso_url` (String) SAML Single Sign-On URL from your identity provider. Required for `saml` and `okta`.

--- a/docs/resources/azure_ad_application.md
+++ b/docs/resources/azure_ad_application.md
@@ -55,6 +55,7 @@ resource "dbtcloud_azure_ad_application" "this" {
 ### Optional
 
 - `azure_service_authentication_method` (String) The method used for service authentication. One of: ~~~service_user~~~, ~~~service_principal~~~. Defaults to ~~~service_user~~~.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/bigquery_credential.md
+++ b/docs/resources/bigquery_credential.md
@@ -42,6 +42,7 @@ resource "dbtcloud_bigquery_credential" "my_credential_v1" {
 
 - `connection_id` (Number) The ID of the global connection to use for this credential. When provided, the credential will automatically use the correct adapter version based on the connection's configuration (e.g., bigquery_v1 for connections with use_latest_adapter=true).
 - `is_active` (Boolean) Whether the BigQuery credential is active
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/bigquery_semantic_layer_credential.md
+++ b/docs/resources/bigquery_semantic_layer_credential.md
@@ -58,6 +58,7 @@ resource "dbtcloud_bigquery_semantic_layer_credential" "example" {
 - `private_key` (String, Sensitive) Private Key for the Service Account. Consider using `private_key_wo` instead, which is not stored in state.
 - `private_key_wo` (String) Write-only alternative to `private_key`. The value is not stored in state. Requires `private_key_wo_version` to trigger updates.
 - `private_key_wo_version` (Number) Version number for `private_key_wo`. Increment this value to trigger an update of the private key when using `private_key_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 
@@ -86,6 +87,7 @@ Optional:
 
 - `connection_id` (Number) The ID of the global connection to use for this credential. When provided, the credential will automatically use the correct adapter version based on the connection's configuration (e.g., bigquery_v1 for connections with use_latest_adapter=true).
 - `is_active` (Boolean) Whether the BigQuery credential is active
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 Read-Only:
 

--- a/docs/resources/connection_catalog_config.md
+++ b/docs/resources/connection_catalog_config.md
@@ -99,6 +99,7 @@ resource "dbtcloud_connection_catalog_config" "with_creds" {
 
 - `database_allow` (List of String) List of database names to include. Supports wildcards (e.g., 'analytics_*'). If set, only these databases are ingested.
 - `database_deny` (List of String) List of database names to exclude. Supports wildcards (e.g., 'staging_*'). Matching databases are not ingested.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `schema_allow` (List of String) List of schema names to include. Supports wildcards (e.g., 'public_*'). If set, only these schemas are ingested.
 - `schema_deny` (List of String) List of schema names to exclude. Supports wildcards (e.g., 'temp_*'). Matching schemas are not ingested.
 - `table_allow` (List of String) List of table names to include. Supports wildcards (e.g., 'fact_*'). If set, only these tables are ingested.

--- a/docs/resources/databricks_credential.md
+++ b/docs/resources/databricks_credential.md
@@ -50,6 +50,7 @@ resource "dbtcloud_databricks_credential" "my_databricks_cred_wo" {
 
 - `adapter_type` (String, Deprecated) The type of the adapter. 'spark' is deprecated, but still supported for backwards compatibility. For Spark, please use the spark_credential resource. Optional only when semantic_layer_credential is set to true; otherwise, this field is required.
 - `catalog` (String) The catalog where to create models (only for the databricks adapter)
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `schema` (String) The schema where to create models. Optional only when semantic_layer_credential is set to true; otherwise, this field is required.
 - `semantic_layer_credential` (Boolean) This field indicates that the credential is used as part of the Semantic Layer configuration. It is used to create a Databricks credential for the Semantic Layer.
 - `target_name` (String, Deprecated) Target name

--- a/docs/resources/databricks_platform_metadata_credential.md
+++ b/docs/resources/databricks_platform_metadata_credential.md
@@ -77,6 +77,7 @@ resource "dbtcloud_databricks_platform_metadata_credential" "example_wo" {
 - `catalog_ingestion_enabled` (Boolean) Whether catalog ingestion is enabled for this credential. When enabled, dbt Cloud will ingest metadata about tables, views, and other objects from your data warehouse.
 - `cost_insights_enabled` (Boolean) Whether cost insights is enabled for this credential.
 - `cost_optimization_enabled` (Boolean) Whether cost optimization data collection is enabled for this credential.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `token` (String, Sensitive) The Databricks personal access token. Consider using `token_wo` instead, which is not stored in state.
 - `token_wo` (String) Write-only alternative to `token`. The value is not stored in state. Requires `token_wo_version` to trigger updates.
 - `token_wo_version` (Number) Version number for `token_wo`. Increment this value to trigger an update of the token when using `token_wo`.

--- a/docs/resources/databricks_semantic_layer_credential.md
+++ b/docs/resources/databricks_semantic_layer_credential.md
@@ -36,6 +36,10 @@ resource "dbtcloud_databricks_semantic_layer_credential" "sl_cred_databricks_exa
 - `configuration` (Attributes) Semantic Layer credential configuration details. (see [below for nested schema](#nestedatt--configuration))
 - `credential` (Attributes) Databricks credential details, but used in the context of the Semantic Layer. (see [below for nested schema](#nestedatt--credential))
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (Number) The ID of the credential
@@ -61,6 +65,7 @@ Optional:
 
 - `adapter_type` (String, Deprecated) The type of the adapter. 'spark' is deprecated, but still supported for backwards compatibility. For Spark, please use the spark_credential resource. Optional only when semantic_layer_credential is set to true; otherwise, this field is required.
 - `catalog` (String) The catalog where to create models (only for the databricks adapter)
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `schema` (String) The schema where to create models. Optional only when semantic_layer_credential is set to true; otherwise, this field is required.
 - `semantic_layer_credential` (Boolean) This field indicates that the credential is used as part of the Semantic Layer configuration. It is used to create a Databricks credential for the Semantic Layer.
 - `target_name` (String, Deprecated) Target name

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -78,6 +78,7 @@ resource "dbtcloud_environment" "profiled_environment" {
 - `extended_attributes_id` (Number) The ID of the extended attributes applied
 - `is_active` (Boolean) Whether the environment is active
 - `primary_profile_id` (Number) The ID of the primary profile for this environment. A profile ties together a connection and credentials. Only applicable to deployment environments. ~> Setting `primary_profile_id` alongside `connection_id`, `credential_id`, or `extended_attributes_id` will produce an error. When a profile is assigned, the API determines those values from the profile. Manage connection, credentials, and extended attributes through the `dbtcloud_profile` resource instead.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `use_custom_branch` (Boolean) Whether to use a custom git branch in this environment
 
 ### Read-Only

--- a/docs/resources/environment_variable.md
+++ b/docs/resources/environment_variable.md
@@ -40,6 +40,10 @@ resource "dbtcloud_environment_variable" "dbt_my_env_var" {
 - `name` (String) Name for the variable, must be unique within a project, must be prefixed with 'DBT_'
 - `project_id` (Number) Project ID to create the environment variable in
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource. Contains the project ID and the environment variable ID.

--- a/docs/resources/environment_variable_job_override.md
+++ b/docs/resources/environment_variable_job_override.md
@@ -31,6 +31,10 @@ resource "dbtcloud_environment_variable_job_override" "my_env_var_job_override" 
 - `project_id` (Number) Project ID to create the environment variable job override in
 - `raw_value` (String) The value for the override of the environment variable
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `account_id` (Number) The account id

--- a/docs/resources/extended_attributes.md
+++ b/docs/resources/extended_attributes.md
@@ -51,6 +51,7 @@ resource "dbtcloud_environment" "issue_depl" {
 
 ### Optional
 
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `state` (Number) The state of the extended attributes (1 = active, 2 = inactive)
 
 ### Read-Only

--- a/docs/resources/fabric_credential.md
+++ b/docs/resources/fabric_credential.md
@@ -88,6 +88,7 @@ resource "dbtcloud_fabric_credential" "my_fabric_cred_serv_princ_wo" {
 - `password` (String, Sensitive) The password for the account to connect to. Only used when connection with AD user/pass. Consider using `password_wo` instead, which is not stored in state.
 - `password_wo` (String) Write-only alternative to `password`. The value is not stored in state. Requires `password_wo_version` to trigger updates.
 - `password_wo_version` (Number) Version number for `password_wo`. Increment this value to trigger an update of the password when using `password_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `schema_authorization` (String) Optionally set this to the principal who should own the schemas created by dbt
 - `tenant_id` (String) The tenant ID of the Azure Active Directory instance. This is only used when connecting to Azure SQL with a service principal.
 - `user` (String) The username of the Fabric account to connect to. Only used when connection with AD user/pass

--- a/docs/resources/global_connection.md
+++ b/docs/resources/global_connection.md
@@ -194,6 +194,7 @@ resource "dbtcloud_global_connection" "teradata" {
 - `postgres` (Attributes) PostgreSQL connection configuration. (see [below for nested schema](#nestedatt--postgres))
 - `private_link_endpoint_id` (String) Private Link Endpoint ID. This ID can be found using the `privatelink_endpoint` data source
 - `redshift` (Attributes) Redshift connection configuration (see [below for nested schema](#nestedatt--redshift))
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `salesforce` (Attributes) Salesforce connection configuration. (see [below for nested schema](#nestedatt--salesforce))
 - `snowflake` (Attributes) Snowflake connection configuration (see [below for nested schema](#nestedatt--snowflake))
 - `starburst` (Attributes) Starburst/Trino connection configuration. (see [below for nested schema](#nestedatt--starburst))

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -72,6 +72,7 @@ resource "dbtcloud_group" "tf_group_1" {
 
 - `assign_by_default` (Boolean) Whether the group will be assigned by default to users. The value needs to be the same for all partial permissions for the same group.
 - `group_permissions` (Block Set) Partial permissions for the group. Those permissions will be added/removed when config is added/removed. (see [below for nested schema](#nestedblock--group_permissions))
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `sso_mapping_groups` (Set of String) Mapping groups from the IdP. At the moment the complete list needs to be provided in each partial permission for the same group.
 
 ### Read-Only

--- a/docs/resources/group_partial_permissions.md
+++ b/docs/resources/group_partial_permissions.md
@@ -80,6 +80,7 @@ resource "dbtcloud_group_partial_permissions" "tf_group_2" {
 
 - `assign_by_default` (Boolean) Whether the group will be assigned by default to users. The value needs to be the same for all partial permissions for the same group.
 - `group_permissions` (Attributes Set) Partial permissions for the group. Those permissions will be added/removed when config is added/removed. (see [below for nested schema](#nestedatt--group_permissions))
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `sso_mapping_groups` (Set of String) Mapping groups from the IdP. At the moment the complete list needs to be provided in each partial permission for the same group.
 
 ### Read-Only
@@ -97,8 +98,8 @@ Required:
 Optional:
 
 - `project_id` (Number) Project ID to apply this permission to for this group.
-- `writable_environment_categories` (Set of String) What types of environments to apply Write permissions to. 
-Even if Write access is restricted to some environment types, the permission set will have Read access to all environments. 
-The values allowed are `all`, `development`, `staging`, `production` and `other`. 
-Not setting a value is the same as selecting `all`. 
+- `writable_environment_categories` (Set of String) What types of environments to apply Write permissions to.
+Even if Write access is restricted to some environment types, the permission set will have Read access to all environments.
+The values allowed are `all`, `development`, `staging`, `production` and `other`.
+Not setting a value is the same as selecting `all`.
 Not all permission sets support environment level write settings, only `analyst`, `database_admin`, `developer`, `git_admin` and `team_admin`.

--- a/docs/resources/ip_restrictions_rule.md
+++ b/docs/resources/ip_restrictions_rule.md
@@ -42,6 +42,7 @@ resource "dbtcloud_ip_restrictions_rule" "test" {
 ### Optional
 
 - `description` (String) A description of the IP restriction rule
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -230,6 +230,7 @@ An example can be found [in this GitHub issue](https://github.com/dbt-labs/terra
 - `job_completion_trigger_condition` (Block List) Which other job should trigger this job when it finishes, and on which conditions (sometimes referred as 'job chaining'). (see [below for nested schema](#nestedblock--job_completion_trigger_condition))
 - `job_type` (String) Can be used to enforce the job type betwen `ci`, `merge` and `scheduled`. Without this value the job type is inferred from the triggers configured
 - `num_threads` (Number) Number of threads to use in the job
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `run_compare_changes` (Boolean) Whether the CI job should compare data changes introduced by the code changes. Requires `deferring_environment_id` to be set. (Advanced CI needs to be activated in the dbt Cloud Account Settings first as well)
 - `run_generate_sources` (Boolean) Flag for whether the job should add a `dbt source freshness` step to the job. The difference between manually adding a step with `dbt source freshness` in the job steps or using this flag is that with this flag, a failed freshness will still allow the following steps to run.
 - `run_lint` (Boolean) Whether the CI job should lint SQL changes. Defaults to `false`.

--- a/docs/resources/license_map.md
+++ b/docs/resources/license_map.md
@@ -41,6 +41,7 @@ resource "dbtcloud_license_map" "it_license_map" {
 
 ### Optional
 
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `sso_license_mapping_groups` (Set of String) SSO license mapping group names for this group
 
 ### Read-Only

--- a/docs/resources/lineage_integration.md
+++ b/docs/resources/lineage_integration.md
@@ -63,6 +63,7 @@ resource "dbtcloud_lineage_integration" "my_lineage_wo" {
 
 ### Optional
 
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `token` (String, Sensitive) The secret token value to use to authenticate to the BI server. Consider using `token_wo` instead, which is not stored in state.
 - `token_wo` (String) Write-only alternative to `token`. The value is not stored in state. Requires `token_wo_version` to trigger updates.
 - `token_wo_version` (Number) Version number for `token_wo`. Increment this value to trigger an update of the token when using `token_wo`.

--- a/docs/resources/model_notifications.md
+++ b/docs/resources/model_notifications.md
@@ -36,6 +36,7 @@ resource "dbtcloud_model_notifications" "prod_model_notifications" {
 - `on_skipped` (Boolean) Whether to send notifications for skipped model runs
 - `on_success` (Boolean) Whether to send notifications for successful model runs
 - `on_warning` (Boolean) Whether to send notifications for model runs with warnings
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -72,6 +72,7 @@ resource "dbtcloud_notification" "prod_job_slack_notifications" {
 - `on_failure` (Set of Number) List of job IDs to trigger the webhook on failure
 - `on_success` (Set of Number) List of job IDs to trigger the webhook on success
 - `on_warning` (Set of Number) List of job IDs to trigger the webhook on warning
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `slack_channel_id` (String) The ID of the Slack channel to receive the notification. It can be found at the bottom of the Slack channel settings
 - `slack_channel_name` (String) The name of the slack channel
 - `state` (Number) State of the notification (1 = active (default), 2 = inactive)

--- a/docs/resources/oauth_configuration.md
+++ b/docs/resources/oauth_configuration.md
@@ -78,6 +78,7 @@ resource "dbtcloud_oauth_configuration" "entra_wo" {
 - `client_secret` (String, Sensitive) The Client secret for the OAuth integration. Consider using `client_secret_wo` instead, which is not stored in state.
 - `client_secret_wo` (String) Write-only alternative to `client_secret`. The value is not stored in state. Requires `client_secret_wo_version` to trigger updates.
 - `client_secret_wo_version` (Number) Version number for `client_secret_wo`. Increment this value to trigger an update of the client secret when using `client_secret_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/openai_integration.md
+++ b/docs/resources/openai_integration.md
@@ -70,6 +70,7 @@ resource "dbtcloud_openai_integration" "azure" {
 - `key_value` (String, Sensitive) The OpenAI or Azure OpenAI API key. Stored as a sensitive value in Terraform state. Conflicts with ~~~key_value_wo~~~. For Terraform 1.11+, prefer ~~~key_value_wo~~~ to avoid storing secrets in state.
 - `key_value_wo` (String) Write-only variant of the API key (Terraform 1.11+). Never stored in state. Increment ~~~key_value_wo_version~~~ to rotate the key. Conflicts with ~~~key_value~~~.
 - `key_value_wo_version` (Number) Increment this value to rotate the key when using ~~~key_value_wo~~~.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/partial_environment_variable.md
+++ b/docs/resources/partial_environment_variable.md
@@ -53,6 +53,10 @@ resource "dbtcloud_partial_environment_variable" "test_env_var_partial" {
 - `name` (String) Name for the variable, must be unique within a project, must be prefixed with 'DBT_'
 - `project_id` (Number) Project ID to create or update the environment variable in
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (String) The ID of the environment variable in the format 'project_id:name'

--- a/docs/resources/partial_license_map.md
+++ b/docs/resources/partial_license_map.md
@@ -49,6 +49,10 @@ resource "dbtcloud_partial_license_map" "it_license_map" {
 - `license_type` (String) The license type to update
 - `sso_license_mapping_groups` (Set of String) List of SSO groups to map to the license type.
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (Number) The ID of the notification

--- a/docs/resources/partial_notification.md
+++ b/docs/resources/partial_notification.md
@@ -87,6 +87,7 @@ resource "dbtcloud_partial_notification" "prod_job_slack_notifications" {
 - `on_failure` (Set of Number) List of job IDs to trigger the webhook on failure Those will be added/removed when config is added/removed.
 - `on_success` (Set of Number) List of job IDs to trigger the webhook on success Those will be added/removed when config is added/removed.
 - `on_warning` (Set of Number) List of job IDs to trigger the webhook on warning Those will be added/removed when config is added/removed.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `slack_channel_id` (String) The ID of the Slack channel to receive the notification. It can be found at the bottom of the Slack channel settings [global, used as identifier]
 - `slack_channel_name` (String) The name of the slack channel [global, used as identifier]
 - `state` (Number) State of the notification (1 = active (default), 2 = inactive) [global]

--- a/docs/resources/postgres_credential.md
+++ b/docs/resources/postgres_credential.md
@@ -61,6 +61,7 @@ resource "dbtcloud_postgres_credential" "postgres_prod_credential_wo" {
 - `password` (String, Sensitive) Password for Postgres/Redshift/AlloyDB. Consider using `password_wo` instead, which is not stored in state.
 - `password_wo` (String) Write-only alternative to `password`. The value is not stored in state. Requires `password_wo_version` to trigger updates.
 - `password_wo_version` (Number) Version number for `password_wo`. Increment this value to trigger an update of the password when using `password_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `semantic_layer_credential` (Boolean) This field indicates that the credential is used as part of the Semantic Layer configuration. It is used to create a Postgres credential for the Semantic Layer.
 - `target_name` (String) Default schema name
 - `type` (String) Type of connection. One of (postgres/redshift). Use postgres for alloydb connections. Optional only when semantic_layer_credential is set to true; otherwise, this field is required.

--- a/docs/resources/postgres_semantic_layer_credential.md
+++ b/docs/resources/postgres_semantic_layer_credential.md
@@ -37,6 +37,10 @@ resource "dbtcloud_postgres_semantic_layer_credential" "test_postgres_semantic_l
 - `configuration` (Attributes) Semantic Layer credential configuration details. (see [below for nested schema](#nestedatt--configuration))
 - `credential` (Attributes) Postgres credential details, but used in the context of the Semantic Layer. (see [below for nested schema](#nestedatt--credential))
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (Number) The ID of the credential
@@ -67,6 +71,7 @@ Optional:
 - `password` (String, Sensitive) Password for Postgres/Redshift/AlloyDB. Consider using `password_wo` instead, which is not stored in state.
 - `password_wo` (String) Write-only alternative to `password`. The value is not stored in state. Requires `password_wo_version` to trigger updates.
 - `password_wo_version` (Number) Version number for `password_wo`. Increment this value to trigger an update of the password when using `password_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `semantic_layer_credential` (Boolean) This field indicates that the credential is used as part of the Semantic Layer configuration. It is used to create a Postgres credential for the Semantic Layer.
 - `target_name` (String) Default schema name
 - `type` (String) Type of connection. One of (postgres/redshift). Use postgres for alloydb connections. Optional only when semantic_layer_credential is set to true; otherwise, this field is required.

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -44,6 +44,7 @@ resource "dbtcloud_profile" "my_profile_with_attrs" {
 ### Optional
 
 - `extended_attributes_id` (Number) The ID of the extended attributes for this profile. Set to null to unset.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -38,6 +38,7 @@ resource "dbtcloud_project" "dbt_project_with_subdir" {
 
 - `dbt_project_subdirectory` (String) DBT project subdirectory
 - `description` (String) Description for the project. Will show in dbt Explorer.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `type` (Number) The type of dbt project (0=default or 1=hybrid)
 
 ### Read-Only

--- a/docs/resources/project_artefacts.md
+++ b/docs/resources/project_artefacts.md
@@ -31,6 +31,7 @@ resource "dbtcloud_project_artefacts" "my_project_artefacts" {
 
 - `docs_job_id` (Number) Docs Job ID
 - `freshness_job_id` (Number) Freshness Job ID
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/project_repository.md
+++ b/docs/resources/project_repository.md
@@ -27,6 +27,10 @@ resource "dbtcloud_project_repository" "dbt_project_repository" {
 - `project_id` (Number) Project ID
 - `repository_id` (Number) Repository ID
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (String) The ID of the project repository.

--- a/docs/resources/redshift_credential.md
+++ b/docs/resources/redshift_credential.md
@@ -59,6 +59,7 @@ resource "dbtcloud_redshift_credential" "redshift_wo" {
 - `password` (String, Sensitive) The password for the Redshift account. Consider using `password_wo` instead, which is not stored in state.
 - `password_wo` (String) Write-only alternative to `password`. The value is not stored in state. Requires `password_wo_version` to trigger updates.
 - `password_wo_version` (Number) Version number for `password_wo`. Increment this value to trigger an update of the password when using `password_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `username` (String) The username for the Redshift account.
 
 ### Read-Only

--- a/docs/resources/redshift_semantic_layer_credential.md
+++ b/docs/resources/redshift_semantic_layer_credential.md
@@ -39,6 +39,10 @@ resource "dbtcloud_redshift_semantic_layer_credential" "test_redshift_semantic_l
 - `configuration` (Attributes) Semantic Layer credential configuration details. (see [below for nested schema](#nestedatt--configuration))
 - `credential` (Attributes) Redshift credential details, but used in the context of the Semantic Layer. (see [below for nested schema](#nestedatt--credential))
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (Number) The ID of the credential
@@ -68,6 +72,7 @@ Optional:
 - `password` (String, Sensitive) The password for the Redshift account. Consider using `password_wo` instead, which is not stored in state.
 - `password_wo` (String) Write-only alternative to `password`. The value is not stored in state. Requires `password_wo_version` to trigger updates.
 - `password_wo_version` (Number) Version number for `password_wo`. Increment this value to trigger an update of the password when using `password_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `username` (String) The username for the Redshift account.
 
 Read-Only:

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -119,6 +119,7 @@ resource "dbtcloud_repository" "ado_repo" {
 - `is_active` (Boolean) Whether the repository is active
 - `private_link_endpoint_id` (String) Identifier for the PrivateLink endpoint.
 - `pull_request_url_template` (String) URL template for creating a pull request. If it is not set, the default template will create a PR from the current branch to the branch configured in the Development environment.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/salesforce_credential.md
+++ b/docs/resources/salesforce_credential.md
@@ -66,6 +66,7 @@ resource "dbtcloud_salesforce_credential" "my_salesforce_cred_wo" {
 - `private_key` (String, Sensitive) The private key for JWT bearer flow authentication. Consider using `private_key_wo` instead, which is not stored in state.
 - `private_key_wo` (String) Write-only alternative to `private_key`. The value is not stored in state. Requires `private_key_wo_version` to trigger updates.
 - `private_key_wo_version` (Number) Version number for `private_key_wo`. Increment this value to trigger an update of the private key when using `private_key_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `target_name` (String) Target name
 
 ### Read-Only

--- a/docs/resources/scim_config.md
+++ b/docs/resources/scim_config.md
@@ -38,6 +38,10 @@ resource "dbtcloud_scim_config" "main" {
 - `manual_updates_allowed` (Boolean) Whether administrators can manually update users and groups that are managed by SCIM. When set to ~~~false~~~, SCIM is the sole source of truth for user and group management.
 - `scim_controlled_license_type` (Boolean) Whether the dbt Cloud license type (Developer, Read-Only, IT) is controlled by SCIM attribute mapping. When set to ~~~false~~~, license types are managed manually inside dbt Cloud.
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (String) The ID of the resource (matches the dbt Cloud account ID).

--- a/docs/resources/scim_config_token.md
+++ b/docs/resources/scim_config_token.md
@@ -44,6 +44,10 @@ output "scim_token" {
 
 - `name` (String) A human-readable name for the token. Changing this value forces a new token to be created.
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `created_at` (String) Timestamp when the token was created.

--- a/docs/resources/scim_group_partial_permissions.md
+++ b/docs/resources/scim_group_partial_permissions.md
@@ -273,6 +273,7 @@ resource "dbtcloud_scim_group_partial_permissions" "data_science" {
 ### Optional
 
 - `permissions` (Attributes Set) Partial set of permissions to apply to the group. These permissions will be added to any existing permissions. Other permissions on the group will not be affected. (see [below for nested schema](#nestedatt--permissions))
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 
@@ -289,10 +290,10 @@ Required:
 Optional:
 
 - `project_id` (Number) Project ID to apply this permission to for this group.
-- `writable_environment_categories` (Set of String) What types of environments to apply Write permissions to. 
-Even if Write access is restricted to some environment types, the permission set will have Read access to all environments. 
-The values allowed are `all`, `development`, `staging`, `production` and `other`. 
-Not setting a value is the same as selecting `all`. 
+- `writable_environment_categories` (Set of String) What types of environments to apply Write permissions to.
+Even if Write access is restricted to some environment types, the permission set will have Read access to all environments.
+The values allowed are `all`, `development`, `staging`, `production` and `other`.
+Not setting a value is the same as selecting `all`.
 Not all permission sets support environment level write settings, only `analyst`, `database_admin`, `developer`, `git_admin` and `team_admin`.
 
 ## Import

--- a/docs/resources/scim_group_permissions.md
+++ b/docs/resources/scim_group_permissions.md
@@ -44,6 +44,7 @@ The resource currently requires a Service Token with Account Admin access.
 ### Optional
 
 - `permissions` (Attributes Set) Set of permissions to apply to the group. This will replace all existing permissions for the group. (see [below for nested schema](#nestedatt--permissions))
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 
@@ -60,8 +61,8 @@ Required:
 Optional:
 
 - `project_id` (Number) Project ID to apply this permission to for this group.
-- `writable_environment_categories` (Set of String) What types of environments to apply Write permissions to. 
-Even if Write access is restricted to some environment types, the permission set will have Read access to all environments. 
-The values allowed are `all`, `development`, `staging`, `production` and `other`. 
-Not setting a value is the same as selecting `all`. 
+- `writable_environment_categories` (Set of String) What types of environments to apply Write permissions to.
+Even if Write access is restricted to some environment types, the permission set will have Read access to all environments.
+The values allowed are `all`, `development`, `staging`, `production` and `other`.
+Not setting a value is the same as selecting `all`.
 Not all permission sets support environment level write settings, only `analyst`, `database_admin`, `developer`, `git_admin` and `team_admin`.

--- a/docs/resources/semantic_layer_configuration.md
+++ b/docs/resources/semantic_layer_configuration.md
@@ -29,6 +29,10 @@ resource "dbtcloud_semantic_layer_configuration" "example" {
 - `environment_id` (Number) The ID of the environment
 - `project_id` (Number) The ID of the project
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (Number) The ID of the configuration

--- a/docs/resources/semantic_layer_credential_service_token_mapping.md
+++ b/docs/resources/semantic_layer_credential_service_token_mapping.md
@@ -29,6 +29,10 @@ resource "dbtcloud_semantic_layer_credential_service_token_mapping" "test_mappin
 - `semantic_layer_credential_id` (Number) The ID of the semantic layer credential to map.
 - `service_token_id` (Number) The ID of the service token to map to the semantic layer credential.
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (Number) The unique identifier of the semantic layer credential service token mapping.

--- a/docs/resources/service_token.md
+++ b/docs/resources/service_token.md
@@ -84,6 +84,7 @@ resource "dbtcloud_service_token" "test_service_token" {
 
 ### Optional
 
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `service_token_permissions` (Block Set) Permissions set for the service token (see [below for nested schema](#nestedblock--service_token_permissions))
 - `state` (Number) Service token state (1 is active, 2 is inactive)
 

--- a/docs/resources/snowflake_credential.md
+++ b/docs/resources/snowflake_credential.md
@@ -65,6 +65,7 @@ resource "dbtcloud_snowflake_credential" "prod_credential_wo" {
 - `private_key_passphrase_wo_version` (Number) Version number for `private_key_passphrase_wo`. Increment this value to trigger an update of the private key passphrase when using `private_key_passphrase_wo`.
 - `private_key_wo` (String) Write-only alternative to `private_key`. The value is not stored in state. Requires `private_key_wo_version` to trigger updates.
 - `private_key_wo_version` (Number) Version number for `private_key_wo`. Increment this value to trigger an update of the private key when using `private_key_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `role` (String) The role to assume
 - `schema` (String) The schema where to create models. This is an optional field ONLY if the credential is used for Semantic Layer configuration, otherwise it is required.
 - `semantic_layer_credential` (Boolean) This field indicates that the credential is used as part of the Semantic Layer configuration. It is used to create a Snowflake credential for the Semantic Layer.

--- a/docs/resources/snowflake_platform_metadata_credential.md
+++ b/docs/resources/snowflake_platform_metadata_credential.md
@@ -137,6 +137,7 @@ resource "dbtcloud_snowflake_platform_metadata_credential" "keypair_auth_wo" {
 - `private_key_passphrase_wo_version` (Number) Version number for `private_key_passphrase_wo`. Increment this value to trigger an update of the private key passphrase when using `private_key_passphrase_wo`.
 - `private_key_wo` (String) Write-only alternative to `private_key`. The value is not stored in state. Requires `private_key_wo_version` to trigger updates.
 - `private_key_wo_version` (Number) Version number for `private_key_wo`. Increment this value to trigger an update of the private key when using `private_key_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/snowflake_semantic_layer_credential.md
+++ b/docs/resources/snowflake_semantic_layer_credential.md
@@ -66,6 +66,10 @@ resource "dbtcloud_snowflake_semantic_layer_credential" "keypair_auth" {
 - `configuration` (Attributes) Semantic Layer credenttial configuration details. (see [below for nested schema](#nestedatt--configuration))
 - `credential` (Attributes) Snowflake credential details, but used in the context of the Semantic Layer. (see [below for nested schema](#nestedatt--credential))
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (Number) The ID of the credential
@@ -102,6 +106,7 @@ Optional:
 - `private_key_passphrase_wo_version` (Number) Version number for `private_key_passphrase_wo`. Increment this value to trigger an update of the private key passphrase when using `private_key_passphrase_wo`.
 - `private_key_wo` (String) Write-only alternative to `private_key`. The value is not stored in state. Requires `private_key_wo_version` to trigger updates.
 - `private_key_wo_version` (Number) Version number for `private_key_wo`. Increment this value to trigger an update of the private key when using `private_key_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `role` (String) The role to assume
 - `schema` (String) The schema where to create models. This is an optional field ONLY if the credential is used for Semantic Layer configuration, otherwise it is required.
 - `semantic_layer_credential` (Boolean) This field indicates that the credential is used as part of the Semantic Layer configuration. It is used to create a Snowflake credential for the Semantic Layer.

--- a/docs/resources/spark_credential.md
+++ b/docs/resources/spark_credential.md
@@ -47,6 +47,7 @@ resource "dbtcloud_spark_credential" "my_spark_cred_wo" {
 
 ### Optional
 
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `target_name` (String, Deprecated) Target name
 - `token` (String, Sensitive) Token for Apache Spark user. Consider using `token_wo` instead, which is not stored in state.
 - `token_wo` (String) Write-only alternative to `token`. The value is not stored in state. Requires `token_wo_version` to trigger updates.

--- a/docs/resources/starburst_credential.md
+++ b/docs/resources/starburst_credential.md
@@ -56,6 +56,7 @@ resource "dbtcloud_starburst_credential" "example_wo" {
 - `password` (String, Sensitive) The password for the Starburst/Trino account. Consider using `password_wo` instead, which is not stored in state.
 - `password_wo` (String) Write-only alternative to `password`. The value is not stored in state. Requires `password_wo_version` to trigger updates.
 - `password_wo_version` (Number) Version number for `password_wo`. Increment this value to trigger an update of the password when using `password_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/docs/resources/synapse_credential.md
+++ b/docs/resources/synapse_credential.md
@@ -103,6 +103,7 @@ resource "dbtcloud_synapse_credential" "my_synapse_cred_serv_princ_wo" {
 - `password` (String, Sensitive) The password for the account to connect to. Only used when connection with AD user/pass. Consider using `password_wo` instead, which is not stored in state.
 - `password_wo` (String) Write-only alternative to `password`. The value is not stored in state. Requires `password_wo_version` to trigger updates.
 - `password_wo_version` (Number) Version number for `password_wo`. Increment this value to trigger an update of the password when using `password_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `schema_authorization` (String) Optionally set this to the principal who should own the schemas created by dbt
 - `tenant_id` (String) The tenant ID of the Azure Active Directory instance. This is only used when connecting to Azure SQL with a service principal.
 - `user` (String) The username of the Synapse account to connect to. Only used when connection with AD user/pass

--- a/docs/resources/teradata_credential.md
+++ b/docs/resources/teradata_credential.md
@@ -53,6 +53,7 @@ resource "dbtcloud_teradata_credential" "example_wo" {
 - `password` (String, Sensitive) The password for the Teradata account. Consider using `password_wo` instead, which is not stored in state.
 - `password_wo` (String) Write-only alternative to `password`. The value is not stored in state. Requires `password_wo_version` to trigger updates.
 - `password_wo_version` (Number) Version number for `password_wo`. Increment this value to trigger an update of the password when using `password_wo`.
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 - `threads` (Number) The number of threads to use. Default is 1
 
 ### Read-Only

--- a/docs/resources/user_groups.md
+++ b/docs/resources/user_groups.md
@@ -50,6 +50,10 @@ resource "dbtcloud_user_groups" "my_other_user_groups" {
 - `group_ids` (Set of Number) IDs of the groups to assign to the user. If additional groups were assigned manually in dbt Cloud, they will be removed.
 - `user_id` (Number) The internal ID of a dbt Cloud user.
 
+### Optional
+
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource. It is the same as the user_id.

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -42,6 +42,7 @@ resource "dbtcloud_webhook" "test_webhook" {
 - `active` (Boolean) Webhooks active flag
 - `description` (String) Webhooks Description
 - `job_ids` (List of Number) List of job IDs to trigger the webhook. When null or empty, the webhook will trigger on all jobs
+- `resource_metadata` (Dynamic) Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.
 
 ### Read-Only
 

--- a/pkg/framework/objects/account_features/model.go
+++ b/pkg/framework/objects/account_features/model.go
@@ -12,5 +12,6 @@ type AccountFeaturesResourceModel struct {
 	AIFeatures                 types.Bool   `tfsdk:"ai_features"`
 	CatalogIngestion           types.Bool   `tfsdk:"catalog_ingestion"`
 	ExplorerAccountUI          types.Bool   `tfsdk:"explorer_account_ui"`
-	FusionMigrationPermissions types.Bool   `tfsdk:"fusion_migration_permissions"`
+	FusionMigrationPermissions types.Bool    `tfsdk:"fusion_migration_permissions"`
+	ResourceMetadata           types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/account_features/schema.go
+++ b/pkg/framework/objects/account_features/schema.go
@@ -64,6 +64,10 @@ func (r *accountFeaturesResource) Schema(
 				Optional:    true,
 				Computed:    true,
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/athena_credential/model.go
+++ b/pkg/framework/objects/athena_credential/model.go
@@ -15,7 +15,8 @@ type AthenaCredentialResourceModel struct {
 	AWSSecretAccessKey          types.String `tfsdk:"aws_secret_access_key"`
 	AWSSecretAccessKeyWo        types.String `tfsdk:"aws_secret_access_key_wo"`
 	AWSSecretAccessKeyWoVersion types.Int64  `tfsdk:"aws_secret_access_key_wo_version"`
-	Schema                      types.String `tfsdk:"schema"`
+	Schema                      types.String  `tfsdk:"schema"`
+	ResourceMetadata            types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 // AthenaCredentialDataSourceModel is the model for the data source

--- a/pkg/framework/objects/athena_credential/schema.go
+++ b/pkg/framework/objects/athena_credential/schema.go
@@ -87,6 +87,10 @@ var resourceSchema = resource_schema.Schema{
 				helper.SchemaNameValidator(),
 			},
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/auth_provider/model.go
+++ b/pkg/framework/objects/auth_provider/model.go
@@ -41,5 +41,6 @@ type AuthProviderResourceModel struct {
 	// Google Workspace only
 	GsuiteAdminID     types.String `tfsdk:"gsuite_admin_id"`
 	AuthorizationURL  types.String `tfsdk:"authorization_url"`
-	AdminRefreshToken types.String `tfsdk:"admin_refresh_token"`
+	AdminRefreshToken types.String  `tfsdk:"admin_refresh_token"`
+	ResourceMetadata  types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/auth_provider/schema.go
+++ b/pkg/framework/objects/auth_provider/schema.go
@@ -213,6 +213,10 @@ func (r *authProviderResource) Schema(
 				Sensitive:   true,
 				Description: "Google Workspace admin OAuth refresh token used to fetch group memberships.",
 			},
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/azure_ad_application/model.go
+++ b/pkg/framework/objects/azure_ad_application/model.go
@@ -14,5 +14,6 @@ type AzureADApplicationResourceModel struct {
 	AzureServiceAuthenticationMethod types.String `tfsdk:"azure_service_authentication_method"`
 	OAuthRedirectURIDomain           types.String `tfsdk:"oauth_redirect_uri_domain"`
 	CreatedAt                        types.String `tfsdk:"created_at"`
-	UpdatedAt                        types.String `tfsdk:"updated_at"`
+	UpdatedAt                        types.String  `tfsdk:"updated_at"`
+	ResourceMetadata                 types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/azure_ad_application/schema.go
+++ b/pkg/framework/objects/azure_ad_application/schema.go
@@ -93,6 +93,10 @@ func (r *azureADApplicationResource) Schema(
 				Computed:    true,
 				Description: "Timestamp when the application was last updated.",
 			},
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/bigquery_credential/model.go
+++ b/pkg/framework/objects/bigquery_credential/model.go
@@ -12,7 +12,8 @@ type BigqueryCredentialResourceModel struct {
 	IsActive     types.Bool   `tfsdk:"is_active"`
 	Dataset      types.String `tfsdk:"dataset"`
 	NumThreads   types.Int64  `tfsdk:"num_threads"`
-	ConnectionID types.Int64  `tfsdk:"connection_id"`
+	ConnectionID     types.Int64   `tfsdk:"connection_id"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 // BigqueryCredentialDataSourceModel is the model for the data source

--- a/pkg/framework/objects/bigquery_credential/schema.go
+++ b/pkg/framework/objects/bigquery_credential/schema.go
@@ -59,6 +59,10 @@ var BigQueryResourceSchema = resource_schema.Schema{
 				int64planmodifier.RequiresReplace(),
 			},
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/connection_catalog_config/model.go
+++ b/pkg/framework/objects/connection_catalog_config/model.go
@@ -17,5 +17,6 @@ type ConnectionCatalogConfigResourceModel struct {
 	TableAllow    types.List `tfsdk:"table_allow"`
 	TableDeny     types.List `tfsdk:"table_deny"`
 	ViewAllow     types.List `tfsdk:"view_allow"`
-	ViewDeny      types.List `tfsdk:"view_deny"`
+	ViewDeny         types.List    `tfsdk:"view_deny"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/connection_catalog_config/schema.go
+++ b/pkg/framework/objects/connection_catalog_config/schema.go
@@ -91,6 +91,10 @@ you must destroy and recreate the resource.
 				Optional:    true,
 				ElementType: types.StringType,
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/databricks_credential/model.go
+++ b/pkg/framework/objects/databricks_credential/model.go
@@ -26,5 +26,6 @@ type DatabricksCredentialResourceModel struct {
 	Catalog                 types.String `tfsdk:"catalog"`
 	Schema                  types.String `tfsdk:"schema"`
 	AdapterType             types.String `tfsdk:"adapter_type"`
-	SemanticLayerCredential types.Bool   `tfsdk:"semantic_layer_credential"`
+	SemanticLayerCredential types.Bool    `tfsdk:"semantic_layer_credential"`
+	ResourceMetadata        types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/databricks_credential/schema.go
+++ b/pkg/framework/objects/databricks_credential/schema.go
@@ -140,5 +140,9 @@ var DatabricksResourceSchema = resource_schema.Schema{
 			Computed:    true,
 			Default:     booldefault.StaticBool(false),
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }

--- a/pkg/framework/objects/environment/model.go
+++ b/pkg/framework/objects/environment/model.go
@@ -24,19 +24,20 @@ type EnvironmentsDataSourceModel struct {
 }
 
 type EnvironmentResourceModel struct {
-	ID                      types.String `tfsdk:"id"`
-	EnvironmentID           types.Int64  `tfsdk:"environment_id"`
-	CredentialID            types.Int64  `tfsdk:"credential_id"`
-	ProjectID               types.Int64  `tfsdk:"project_id"`
-	IsActive                types.Bool   `tfsdk:"is_active"`
-	Name                    types.String `tfsdk:"name"`
-	DbtVersion              types.String `tfsdk:"dbt_version"`
-	Type                    types.String `tfsdk:"type"`
-	UseCustomBranch         types.Bool   `tfsdk:"use_custom_branch"`
-	CustomBranch            types.String `tfsdk:"custom_branch"`
-	DeploymentType          types.String `tfsdk:"deployment_type"`
-	ExtendedAttributesID    types.Int64  `tfsdk:"extended_attributes_id"`
-	ConnectionID            types.Int64  `tfsdk:"connection_id"`
-	EnableModelQueryHistory types.Bool   `tfsdk:"enable_model_query_history"`
-	PrimaryProfileID        types.Int64  `tfsdk:"primary_profile_id"`
+	ID                      types.String  `tfsdk:"id"`
+	EnvironmentID           types.Int64   `tfsdk:"environment_id"`
+	CredentialID            types.Int64   `tfsdk:"credential_id"`
+	ProjectID               types.Int64   `tfsdk:"project_id"`
+	IsActive                types.Bool    `tfsdk:"is_active"`
+	Name                    types.String  `tfsdk:"name"`
+	DbtVersion              types.String  `tfsdk:"dbt_version"`
+	Type                    types.String  `tfsdk:"type"`
+	UseCustomBranch         types.Bool    `tfsdk:"use_custom_branch"`
+	CustomBranch            types.String  `tfsdk:"custom_branch"`
+	DeploymentType          types.String  `tfsdk:"deployment_type"`
+	ExtendedAttributesID    types.Int64   `tfsdk:"extended_attributes_id"`
+	ConnectionID            types.Int64   `tfsdk:"connection_id"`
+	EnableModelQueryHistory types.Bool    `tfsdk:"enable_model_query_history"`
+	PrimaryProfileID        types.Int64   `tfsdk:"primary_profile_id"`
+	ResourceMetadata        types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/environment/schema.go
+++ b/pkg/framework/objects/environment/schema.go
@@ -290,6 +290,10 @@ func (r *environmentResource) Schema(
 					validators.PrimaryProfileValidator{},
 				},
 			},
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/environment_variable/model.go
+++ b/pkg/framework/objects/environment_variable/model.go
@@ -6,10 +6,11 @@ import (
 
 // EnvironmentVariableResourceModel is the model for the resource
 type EnvironmentVariableResourceModel struct {
-	ID                types.String `tfsdk:"id"`
-	ProjectID         types.Int64  `tfsdk:"project_id"`
-	Name              types.String `tfsdk:"name"`
-	EnvironmentValues types.Map    `tfsdk:"environment_values"`
+	ID                types.String  `tfsdk:"id"`
+	ProjectID         types.Int64   `tfsdk:"project_id"`
+	Name              types.String  `tfsdk:"name"`
+	EnvironmentValues types.Map     `tfsdk:"environment_values"`
+	ResourceMetadata  types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 // EnvironmentVariableDataSourceModel is the model for the data source

--- a/pkg/framework/objects/environment_variable/schema.go
+++ b/pkg/framework/objects/environment_variable/schema.go
@@ -35,6 +35,10 @@ var resourceSchema = resource_schema.Schema{
 			ElementType: types.StringType,
 			Description: "Map from environment names to respective variable value, a special key `project` should be set for the project default variable value. This field is not set as sensitive so take precautions when using secret environment variables.",
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/environment_variable_job_override/model.go
+++ b/pkg/framework/objects/environment_variable_job_override/model.go
@@ -12,5 +12,6 @@ type EnvironmentVariableJobOverrideResourceModel struct {
 	Name                             types.String `tfsdk:"name"`
 	JobDefinitionID                  types.Int64  `tfsdk:"job_definition_id"`
 	RawValue                         types.String `tfsdk:"raw_value"`
-	EnvironmentVariableJobOverrideID types.Int64  `tfsdk:"environment_variable_job_override_id"`
+	EnvironmentVariableJobOverrideID types.Int64   `tfsdk:"environment_variable_job_override_id"`
+	ResourceMetadata                 types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/environment_variable_job_override/schema.go
+++ b/pkg/framework/objects/environment_variable_job_override/schema.go
@@ -56,5 +56,9 @@ var resourceSchema = resource_schema.Schema{
 				stringplanmodifier.RequiresReplace(),
 			},
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }

--- a/pkg/framework/objects/extended_attributes/model.go
+++ b/pkg/framework/objects/extended_attributes/model.go
@@ -5,11 +5,12 @@ import (
 )
 
 type ExtendedAttributesResourceModel struct {
-	ID                   types.String `tfsdk:"id"`
-	ExtendedAttributesID types.Int64  `tfsdk:"extended_attributes_id"`
-	State                types.Int64  `tfsdk:"state"`
-	ProjectID            types.Int64  `tfsdk:"project_id"`
-	ExtendedAttributes   types.String `tfsdk:"extended_attributes"`
+	ID                   types.String  `tfsdk:"id"`
+	ExtendedAttributesID types.Int64   `tfsdk:"extended_attributes_id"`
+	State                types.Int64   `tfsdk:"state"`
+	ProjectID            types.Int64   `tfsdk:"project_id"`
+	ExtendedAttributes   types.String  `tfsdk:"extended_attributes"`
+	ResourceMetadata     types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 type ExtendedAttributesDataSourceModel struct {

--- a/pkg/framework/objects/extended_attributes/schema.go
+++ b/pkg/framework/objects/extended_attributes/schema.go
@@ -76,6 +76,10 @@ var resourceSchema = resource_schema.Schema{
 				extendedAttributesPlanModifier{},
 			},
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/fabric_credential/model.go
+++ b/pkg/framework/objects/fabric_credential/model.go
@@ -20,5 +20,6 @@ type FabricCredentialResourceModel struct {
 	ClientSecretWoVersion  types.Int64  `tfsdk:"client_secret_wo_version"`
 	Schema                 types.String `tfsdk:"schema"`
 	SchemaAuthorization    types.String `tfsdk:"schema_authorization"`
-	AdapterType            types.String `tfsdk:"adapter_type"`
+	AdapterType            types.String  `tfsdk:"adapter_type"`
+	ResourceMetadata       types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/fabric_credential/schema.go
+++ b/pkg/framework/objects/fabric_credential/schema.go
@@ -154,6 +154,10 @@ var resourceSchema = resource_schema.Schema{
 				stringvalidator.OneOf("fabric"),
 			},
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/global_connection/model.go
+++ b/pkg/framework/objects/global_connection/model.go
@@ -151,6 +151,7 @@ type GlobalConnectionResourceModel struct {
 	ApacheSparkConfig     *ApacheSparkConfig `tfsdk:"apache_spark"`
 	TeradataConfig        *TeradataConfig    `tfsdk:"teradata"`
 	SalesforceConfig      *SalesforceConfig  `tfsdk:"salesforce"`
+	ResourceMetadata      types.Dynamic      `tfsdk:"resource_metadata"`
 }
 
 type SSHTunnelConfig struct {

--- a/pkg/framework/objects/global_connection/schema.go
+++ b/pkg/framework/objects/global_connection/schema.go
@@ -643,6 +643,10 @@ func (r *globalConnectionResource) Schema(
 					},
 				},
 			},
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/global_connection/schema.go
+++ b/pkg/framework/objects/global_connection/schema.go
@@ -1172,6 +1172,10 @@ func (r *globalConnectionDataSource) Schema(
 					},
 				},
 			},
+			"resource_metadata": datasource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/group/model.go
+++ b/pkg/framework/objects/group/model.go
@@ -15,6 +15,7 @@ type GroupResourceModel struct {
 	AssignByDefault  types.Bool        `tfsdk:"assign_by_default"`
 	SSOMappingGroups types.Set         `tfsdk:"sso_mapping_groups"`
 	GroupPermissions []GroupPermission `tfsdk:"group_permissions"`
+	ResourceMetadata types.Dynamic     `tfsdk:"resource_metadata"`
 }
 
 // we need a different one just because historically the data source uses `group_id` instead of `id`

--- a/pkg/framework/objects/group/schema.go
+++ b/pkg/framework/objects/group/schema.go
@@ -93,6 +93,10 @@ func (r *groupResource) Schema(
 			// 	},
 			// 	Optional: true,
 			// },
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 		// For now we use a Block to move from SDKv2 to PLugin Framework, but we might change to a SetAttribute in the future, using the code from above
 		Blocks: map[string]resource_schema.Block{

--- a/pkg/framework/objects/group_partial_permissions/schema.go
+++ b/pkg/framework/objects/group_partial_permissions/schema.go
@@ -95,16 +95,20 @@ func (r *groupPartialPermissionsResource) Schema(
 							ElementType: types.StringType,
 							Optional:    true,
 							Description: helper.DocString(
-								`What types of environments to apply Write permissions to. 
-								Even if Write access is restricted to some environment types, the permission set will have Read access to all environments. 
-								The values allowed are ~~~all~~~, ~~~development~~~, ~~~staging~~~, ~~~production~~~ and ~~~other~~~. 
-								Not setting a value is the same as selecting ~~~all~~~. 
+								`What types of environments to apply Write permissions to.
+								Even if Write access is restricted to some environment types, the permission set will have Read access to all environments.
+								The values allowed are ~~~all~~~, ~~~development~~~, ~~~staging~~~, ~~~production~~~ and ~~~other~~~.
+								Not setting a value is the same as selecting ~~~all~~~.
 								Not all permission sets support environment level write settings, only ~~~analyst~~~, ~~~database_admin~~~, ~~~developer~~~, ~~~git_admin~~~ and ~~~team_admin~~~.`,
 							),
 						},
 					},
 				},
 				Optional: true,
+			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
 			},
 		},
 	}

--- a/pkg/framework/objects/ip_restrictions_rule/model.go
+++ b/pkg/framework/objects/ip_restrictions_rule/model.go
@@ -6,12 +6,13 @@ import (
 )
 
 type IPRestrictionsRuleResourceModel struct {
-	ID             types.Int64  `tfsdk:"id"`
-	Name           types.String `tfsdk:"name"`
-	Type           types.String `tfsdk:"type"`
-	Description    types.String `tfsdk:"description"`
-	RuleSetEnabled types.Bool   `tfsdk:"rule_set_enabled"`
-	Cidrs          []CidrModel  `tfsdk:"cidrs"`
+	ID               types.Int64   `tfsdk:"id"`
+	Name             types.String  `tfsdk:"name"`
+	Type             types.String  `tfsdk:"type"`
+	Description      types.String  `tfsdk:"description"`
+	RuleSetEnabled   types.Bool    `tfsdk:"rule_set_enabled"`
+	Cidrs            []CidrModel   `tfsdk:"cidrs"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 type CidrModel struct {

--- a/pkg/framework/objects/ip_restrictions_rule/schema.go
+++ b/pkg/framework/objects/ip_restrictions_rule/schema.go
@@ -76,6 +76,10 @@ func (r *ipRestrictionsRuleResource) Schema(
 					},
 				},
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/job/model.go
+++ b/pkg/framework/objects/job/model.go
@@ -137,4 +137,5 @@ type JobResourceModel struct {
 	DeferringJobId                types.Int64                      `tfsdk:"deferring_job_id"` // add deprecated move to deferring_job_definition_id
 	SelfDeferring                 types.Bool                       `tfsdk:"self_deferring"`
 	CompareChangesFlags           types.String                     `tfsdk:"compare_changes_flags"`
+	ResourceMetadata              types.Dynamic                    `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/job/schema.go
+++ b/pkg/framework/objects/job/schema.go
@@ -646,6 +646,10 @@ func (j *jobResource) Schema(
 			// 		},
 			// 	},
 			// },
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 		Blocks: map[string]resource_schema.Block{
 			"job_completion_trigger_condition": resource_schema.ListNestedBlock{

--- a/pkg/framework/objects/license_map/model.go
+++ b/pkg/framework/objects/license_map/model.go
@@ -5,7 +5,8 @@ import (
 )
 
 type LicenseMapResourceModel struct {
-	ID                      types.Int64  `tfsdk:"id"`
-	LicenseType             types.String `tfsdk:"license_type"`
-	SSOLicenseMappingGroups types.Set    `tfsdk:"sso_license_mapping_groups"`
+	ID                      types.Int64   `tfsdk:"id"`
+	LicenseType             types.String  `tfsdk:"license_type"`
+	SSOLicenseMappingGroups types.Set     `tfsdk:"sso_license_mapping_groups"`
+	ResourceMetadata        types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/license_map/schema.go
+++ b/pkg/framework/objects/license_map/schema.go
@@ -41,6 +41,10 @@ func (r *licenseMapResource) Schema(
 				Description: "SSO license mapping group names for this group",
 				ElementType: types.StringType,
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/lineage_integration/model.go
+++ b/pkg/framework/objects/lineage_integration/model.go
@@ -12,5 +12,6 @@ type LineageIntegrationResourceModel struct {
 	TokenName            types.String `tfsdk:"token_name"`
 	Token                types.String `tfsdk:"token"`
 	TokenWo              types.String `tfsdk:"token_wo"`
-	TokenWoVersion       types.Int64  `tfsdk:"token_wo_version"`
+	TokenWoVersion       types.Int64   `tfsdk:"token_wo_version"`
+	ResourceMetadata     types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/lineage_integration/schema.go
+++ b/pkg/framework/objects/lineage_integration/schema.go
@@ -90,6 +90,10 @@ func (r *lineageIntegrationResource) Schema(
 				Optional:    true,
 				Description: "Version number for `token_wo`. Increment this value to trigger an update of the token when using `token_wo`.",
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/model_notifications/model.go
+++ b/pkg/framework/objects/model_notifications/model.go
@@ -8,13 +8,14 @@ import (
 )
 
 type ModelNotificationsResourceModel struct {
-	ID            types.String `tfsdk:"id"`
-	EnvironmentID types.String `tfsdk:"environment_id"`
-	Enabled       types.Bool   `tfsdk:"enabled"`
-	OnSuccess     types.Bool   `tfsdk:"on_success"`
-	OnFailure     types.Bool   `tfsdk:"on_failure"`
-	OnWarning     types.Bool   `tfsdk:"on_warning"`
-	OnSkipped     types.Bool   `tfsdk:"on_skipped"`
+	ID               types.String  `tfsdk:"id"`
+	EnvironmentID    types.String  `tfsdk:"environment_id"`
+	Enabled          types.Bool    `tfsdk:"enabled"`
+	OnSuccess        types.Bool    `tfsdk:"on_success"`
+	OnFailure        types.Bool    `tfsdk:"on_failure"`
+	OnWarning        types.Bool    `tfsdk:"on_warning"`
+	OnSkipped        types.Bool    `tfsdk:"on_skipped"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 type ModelNotificationsDataSourceModel struct {

--- a/pkg/framework/objects/model_notifications/schema.go
+++ b/pkg/framework/objects/model_notifications/schema.go
@@ -62,6 +62,10 @@ func (r *modelNotificationsResource) Schema(
 				Default:     booldefault.StaticBool(false),
 				Description: "Whether to send notifications for skipped model runs",
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/notification/model.go
+++ b/pkg/framework/objects/notification/model.go
@@ -9,17 +9,18 @@ import (
 )
 
 type NotificationResourceModel struct {
-	ID               types.String `tfsdk:"id"`
-	UserID           types.Int64  `tfsdk:"user_id"`
-	OnCancel         types.Set    `tfsdk:"on_cancel"`
-	OnFailure        types.Set    `tfsdk:"on_failure"`
-	OnWarning        types.Set    `tfsdk:"on_warning"`
-	OnSuccess        types.Set    `tfsdk:"on_success"`
-	State            types.Int64  `tfsdk:"state"`
-	NotificationType types.Int64  `tfsdk:"notification_type"`
-	ExternalEmail    types.String `tfsdk:"external_email"`
-	SlackChannelID   types.String `tfsdk:"slack_channel_id"`
-	SlackChannelName types.String `tfsdk:"slack_channel_name"`
+	ID               types.String  `tfsdk:"id"`
+	UserID           types.Int64   `tfsdk:"user_id"`
+	OnCancel         types.Set     `tfsdk:"on_cancel"`
+	OnFailure        types.Set     `tfsdk:"on_failure"`
+	OnWarning        types.Set     `tfsdk:"on_warning"`
+	OnSuccess        types.Set     `tfsdk:"on_success"`
+	State            types.Int64   `tfsdk:"state"`
+	NotificationType types.Int64   `tfsdk:"notification_type"`
+	ExternalEmail    types.String  `tfsdk:"external_email"`
+	SlackChannelID   types.String  `tfsdk:"slack_channel_id"`
+	SlackChannelName types.String  `tfsdk:"slack_channel_name"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 type NotificationDataSourceModel struct {

--- a/pkg/framework/objects/notification/schema.go
+++ b/pkg/framework/objects/notification/schema.go
@@ -103,6 +103,10 @@ func (r *notificationResource) Schema(
 					stringvalidator.ConflictsWith(path.MatchRoot("external_email")),
 				},
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/oauth_configuration/model.go
+++ b/pkg/framework/objects/oauth_configuration/model.go
@@ -15,5 +15,6 @@ type OAuthConfigurationResourceModel struct {
 	AuthorizeUrl     types.String `tfsdk:"authorize_url"`
 	TokenUrl         types.String `tfsdk:"token_url"`
 	RedirectUri      types.String `tfsdk:"redirect_uri"`
-	ApplicationIdUri types.String `tfsdk:"application_id_uri"`
+	ApplicationIdUri types.String  `tfsdk:"application_id_uri"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/oauth_configuration/schema.go
+++ b/pkg/framework/objects/oauth_configuration/schema.go
@@ -89,6 +89,10 @@ func (r *oAuthConfigurationResource) Schema(
 				Description: "The Application ID URI for the OAuth integration. Only for Entra",
 				Default:     stringdefault.StaticString(""),
 			},
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/openai_integration/model.go
+++ b/pkg/framework/objects/openai_integration/model.go
@@ -15,5 +15,6 @@ type OpenAIIntegrationResourceModel struct {
 	AzureDeploymentName types.String `tfsdk:"azure_deployment_name"`
 	AzureAPIVersion     types.String `tfsdk:"azure_api_version"`
 	CreatedAt           types.String `tfsdk:"created_at"`
-	UpdatedAt           types.String `tfsdk:"updated_at"`
+	UpdatedAt           types.String  `tfsdk:"updated_at"`
+	ResourceMetadata    types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/openai_integration/schema.go
+++ b/pkg/framework/objects/openai_integration/schema.go
@@ -99,6 +99,10 @@ func (r *openAIIntegrationResource) Schema(
 				Computed:    true,
 				Description: "Timestamp when the integration was last updated.",
 			},
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/partial_environment_variable/schema.go
+++ b/pkg/framework/objects/partial_environment_variable/schema.go
@@ -71,6 +71,10 @@ resource "dbtcloud_partial_environment_variable" "test_env_var_partial" {
 				Required:    true,
 				Description: "Map from environment names to respective variable value. This field is not set as sensitive so take precautions when using secret environment variables. Only the specified environment values will be managed by this resource.",
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/partial_license_map/schema.go
+++ b/pkg/framework/objects/partial_license_map/schema.go
@@ -50,6 +50,10 @@ func (r *partialLicenseMapResource) Schema(
 				Required:    true,
 				Description: "List of SSO groups to map to the license type.",
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/partial_notification/schema.go
+++ b/pkg/framework/objects/partial_notification/schema.go
@@ -132,6 +132,10 @@ func (r *partialNotificationResource) Schema(
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/platform_metadata_credentials/model.go
+++ b/pkg/framework/objects/platform_metadata_credentials/model.go
@@ -32,6 +32,8 @@ type SnowflakePlatformMetadataCredentialResourceModel struct {
 
 	// Read-only fields
 	AdapterVersion types.String `tfsdk:"adapter_version"`
+
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 // DatabricksPlatformMetadataCredentialResourceModel represents the Terraform state for Databricks
@@ -53,4 +55,6 @@ type DatabricksPlatformMetadataCredentialResourceModel struct {
 
 	// Read-only fields
 	AdapterVersion types.String `tfsdk:"adapter_version"`
+
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/platform_metadata_credentials/schema.go
+++ b/pkg/framework/objects/platform_metadata_credentials/schema.go
@@ -62,6 +62,10 @@ func commonAttributes() map[string]schema.Attribute {
 				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
+		"resource_metadata": schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	}
 }
 

--- a/pkg/framework/objects/postgres_credential/model.go
+++ b/pkg/framework/objects/postgres_credential/model.go
@@ -27,5 +27,6 @@ type PostgresCredentialResourceModel struct {
 	Password                types.String `tfsdk:"password"`
 	PasswordWo              types.String `tfsdk:"password_wo"`
 	PasswordWoVersion       types.Int64  `tfsdk:"password_wo_version"`
-	SemanticLayerCredential types.Bool   `tfsdk:"semantic_layer_credential"`
+	SemanticLayerCredential types.Bool    `tfsdk:"semantic_layer_credential"`
+	ResourceMetadata        types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/postgres_credential/schema.go
+++ b/pkg/framework/objects/postgres_credential/schema.go
@@ -143,5 +143,9 @@ var PostgresResourceSchema = resource_schema.Schema{
 				boolplanmodifier.UseStateForUnknown(),
 			},
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }

--- a/pkg/framework/objects/profile/model.go
+++ b/pkg/framework/objects/profile/model.go
@@ -5,13 +5,14 @@ import (
 )
 
 type ProfileResourceModel struct {
-	ID                   types.String `tfsdk:"id"`
-	ProfileID            types.Int64  `tfsdk:"profile_id"`
-	ProjectID            types.Int64  `tfsdk:"project_id"`
-	Key                  types.String `tfsdk:"key"`
-	ConnectionID         types.Int64  `tfsdk:"connection_id"`
-	CredentialsID        types.Int64  `tfsdk:"credentials_id"`
-	ExtendedAttributesID types.Int64  `tfsdk:"extended_attributes_id"`
+	ID                   types.String  `tfsdk:"id"`
+	ProfileID            types.Int64   `tfsdk:"profile_id"`
+	ProjectID            types.Int64   `tfsdk:"project_id"`
+	Key                  types.String  `tfsdk:"key"`
+	ConnectionID         types.Int64   `tfsdk:"connection_id"`
+	CredentialsID        types.Int64   `tfsdk:"credentials_id"`
+	ExtendedAttributesID types.Int64   `tfsdk:"extended_attributes_id"`
+	ResourceMetadata     types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 type ProfileDataSourceModel struct {

--- a/pkg/framework/objects/profile/schema.go
+++ b/pkg/framework/objects/profile/schema.go
@@ -48,6 +48,10 @@ var resourceSchema = resource_schema.Schema{
 			Description: "The ID of the extended attributes for this profile. Set to null to unset.",
 			Optional:    true,
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/project/model.go
+++ b/pkg/framework/objects/project/model.go
@@ -49,9 +49,10 @@ type ProjectConnection struct {
 }
 
 type ProjectResourceModel struct {
-	ID                     types.Int64  `tfsdk:"id"`
-	Name                   types.String `tfsdk:"name"`
-	Description            types.String `tfsdk:"description"`
-	DbtProjectSubdirectory types.String `tfsdk:"dbt_project_subdirectory"`
-	DbtProjectType         types.Int64  `tfsdk:"type"`
+	ID                     types.Int64   `tfsdk:"id"`
+	Name                   types.String  `tfsdk:"name"`
+	Description            types.String  `tfsdk:"description"`
+	DbtProjectSubdirectory types.String  `tfsdk:"dbt_project_subdirectory"`
+	DbtProjectType         types.Int64   `tfsdk:"type"`
+	ResourceMetadata       types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/project/schema.go
+++ b/pkg/framework/objects/project/schema.go
@@ -222,5 +222,9 @@ var resourceSchema = resource_schema.Schema{
 				int64planmodifier.UseStateForUnknown(),
 			},
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }

--- a/pkg/framework/objects/project_artefacts/model.go
+++ b/pkg/framework/objects/project_artefacts/model.go
@@ -5,8 +5,9 @@ import (
 )
 
 type ProjectArtefactsResourceModel struct {
-	ID             types.String `tfsdk:"id"`
-	ProjectID      types.Int64  `tfsdk:"project_id"`
-	DocsJobID      types.Int64  `tfsdk:"docs_job_id"`
-	FreshnessJobID types.Int64  `tfsdk:"freshness_job_id"`
+	ID               types.String  `tfsdk:"id"`
+	ProjectID        types.Int64   `tfsdk:"project_id"`
+	DocsJobID        types.Int64   `tfsdk:"docs_job_id"`
+	FreshnessJobID   types.Int64   `tfsdk:"freshness_job_id"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/project_artefacts/schema.go
+++ b/pkg/framework/objects/project_artefacts/schema.go
@@ -42,6 +42,10 @@ func (p *projectArtefactsResource) Schema(_ context.Context, _ resource.SchemaRe
 				Computed:    true,
 				Default:     int64default.StaticInt64(0),
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/project_repository/model.go
+++ b/pkg/framework/objects/project_repository/model.go
@@ -6,7 +6,8 @@ import (
 
 // Model represents the resource model for a project repository
 type Model struct {
-	ID           types.String `tfsdk:"id"`
-	ProjectID    types.Int64  `tfsdk:"project_id"`
-	RepositoryID types.Int64  `tfsdk:"repository_id"`
+	ID               types.String  `tfsdk:"id"`
+	ProjectID        types.Int64   `tfsdk:"project_id"`
+	RepositoryID     types.Int64   `tfsdk:"repository_id"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/project_repository/schema.go
+++ b/pkg/framework/objects/project_repository/schema.go
@@ -29,6 +29,10 @@ func Schema() schema.Schema {
 					int64planmodifier.RequiresReplace(),
 				},
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/redshift_credential/model.go
+++ b/pkg/framework/objects/redshift_credential/model.go
@@ -14,7 +14,8 @@ type RedshiftCredentialResourceModel struct {
 	PasswordWo        types.String `tfsdk:"password_wo"`
 	PasswordWoVersion types.Int64  `tfsdk:"password_wo_version"`
 	DefaultSchema     types.String `tfsdk:"default_schema"`
-	NumThreads        types.Int64  `tfsdk:"num_threads"`
+	NumThreads        types.Int64   `tfsdk:"num_threads"`
+	ResourceMetadata  types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 type RedshiftCredentialDataSourceModel struct {

--- a/pkg/framework/objects/redshift_credential/schema.go
+++ b/pkg/framework/objects/redshift_credential/schema.go
@@ -85,6 +85,10 @@ var RedshiftResourceSchema = resource_schema.Schema{
 			Required:    true,
 			Description: "Number of threads to use",
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/repository/model.go
+++ b/pkg/framework/objects/repository/model.go
@@ -24,20 +24,21 @@ type RepositoryDataSourceModel struct {
 }
 
 type RepositoryResourceModel struct {
-	ID                                    types.String `tfsdk:"id"`
-	RepositoryID                          types.Int64  `tfsdk:"repository_id"`
-	ProjectID                             types.Int64  `tfsdk:"project_id"`
-	IsActive                              types.Bool   `tfsdk:"is_active"`
-	RemoteURL                             types.String `tfsdk:"remote_url"`
-	GitCloneStrategy                      types.String `tfsdk:"git_clone_strategy"`
-	RepositoryCredentialsID               types.Int64  `tfsdk:"repository_credentials_id"`
-	GitlabProjectID                       types.Int64  `tfsdk:"gitlab_project_id"`
-	GithubInstallationID                  types.Int64  `tfsdk:"github_installation_id"`
-	PrivateLinkEndpointID                 types.String `tfsdk:"private_link_endpoint_id"`
-	DeployKey                             types.String `tfsdk:"deploy_key"`
-	PullRequestURLTemplate                types.String `tfsdk:"pull_request_url_template"`
-	AzureActiveDirectoryProjectID         types.String `tfsdk:"azure_active_directory_project_id"`
-	AzureActiveDirectoryRepositoryID      types.String `tfsdk:"azure_active_directory_repository_id"`
-	AzureBypassWebhookRegistrationFailure types.Bool   `tfsdk:"azure_bypass_webhook_registration_failure"`
-	FetchDeployKey                        types.Bool   `tfsdk:"fetch_deploy_key"`
+	ID                                    types.String  `tfsdk:"id"`
+	RepositoryID                          types.Int64   `tfsdk:"repository_id"`
+	ProjectID                             types.Int64   `tfsdk:"project_id"`
+	IsActive                              types.Bool    `tfsdk:"is_active"`
+	RemoteURL                             types.String  `tfsdk:"remote_url"`
+	GitCloneStrategy                      types.String  `tfsdk:"git_clone_strategy"`
+	RepositoryCredentialsID               types.Int64   `tfsdk:"repository_credentials_id"`
+	GitlabProjectID                       types.Int64   `tfsdk:"gitlab_project_id"`
+	GithubInstallationID                  types.Int64   `tfsdk:"github_installation_id"`
+	PrivateLinkEndpointID                 types.String  `tfsdk:"private_link_endpoint_id"`
+	DeployKey                             types.String  `tfsdk:"deploy_key"`
+	PullRequestURLTemplate                types.String  `tfsdk:"pull_request_url_template"`
+	AzureActiveDirectoryProjectID         types.String  `tfsdk:"azure_active_directory_project_id"`
+	AzureActiveDirectoryRepositoryID      types.String  `tfsdk:"azure_active_directory_repository_id"`
+	AzureBypassWebhookRegistrationFailure types.Bool    `tfsdk:"azure_bypass_webhook_registration_failure"`
+	FetchDeployKey                        types.Bool    `tfsdk:"fetch_deploy_key"`
+	ResourceMetadata                      types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/repository/schema.go
+++ b/pkg/framework/objects/repository/schema.go
@@ -123,6 +123,10 @@ func ResourceSchema() resource_schema.Schema {
 				Computed:    true,
 				Description: "URL template for creating a pull request. If it is not set, the default template will create a PR from the current branch to the branch configured in the Development environment.",
 			},
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/salesforce_credential/model.go
+++ b/pkg/framework/objects/salesforce_credential/model.go
@@ -25,5 +25,6 @@ type SalesforceCredentialResourceModel struct {
 	PrivateKeyWo        types.String `tfsdk:"private_key_wo"`
 	PrivateKeyWoVersion types.Int64  `tfsdk:"private_key_wo_version"`
 	TargetName          types.String `tfsdk:"target_name"`
-	NumThreads          types.Int64  `tfsdk:"num_threads"`
+	NumThreads          types.Int64   `tfsdk:"num_threads"`
+	ResourceMetadata    types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/salesforce_credential/schema.go
+++ b/pkg/framework/objects/salesforce_credential/schema.go
@@ -125,5 +125,9 @@ var SalesforceResourceSchema = resource_schema.Schema{
 			Computed:    true,
 			Default:     int64default.StaticInt64(6),
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }

--- a/pkg/framework/objects/scim_config/model.go
+++ b/pkg/framework/objects/scim_config/model.go
@@ -5,8 +5,9 @@ import (
 )
 
 type SCIMConfigResourceModel struct {
-	ID                        types.String `tfsdk:"id"`
-	Enabled                   types.Bool   `tfsdk:"enabled"`
-	ManualUpdatesAllowed      types.Bool   `tfsdk:"manual_updates_allowed"`
-	SCIMControlledLicenseType types.Bool   `tfsdk:"scim_controlled_license_type"`
+	ID                        types.String  `tfsdk:"id"`
+	Enabled                   types.Bool    `tfsdk:"enabled"`
+	ManualUpdatesAllowed      types.Bool    `tfsdk:"manual_updates_allowed"`
+	SCIMControlledLicenseType types.Bool    `tfsdk:"scim_controlled_license_type"`
+	ResourceMetadata          types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/scim_config/schema.go
+++ b/pkg/framework/objects/scim_config/schema.go
@@ -43,6 +43,10 @@ func (r *scimConfigResource) Schema(
 				Required:    true,
 				Description: "Whether the dbt Cloud license type (Developer, Read-Only, IT) is controlled by SCIM attribute mapping. When set to ~~~false~~~, license types are managed manually inside dbt Cloud.",
 			},
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/scim_config_token/model.go
+++ b/pkg/framework/objects/scim_config_token/model.go
@@ -5,9 +5,10 @@ import (
 )
 
 type SCIMConfigTokenResourceModel struct {
-	ID          types.Int64  `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	TokenString types.String `tfsdk:"token_string"`
-	CreatedAt   types.String `tfsdk:"created_at"`
-	LastUsed    types.String `tfsdk:"last_used"`
+	ID               types.Int64   `tfsdk:"id"`
+	Name             types.String  `tfsdk:"name"`
+	TokenString      types.String  `tfsdk:"token_string"`
+	CreatedAt        types.String  `tfsdk:"created_at"`
+	LastUsed         types.String  `tfsdk:"last_used"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/scim_config_token/schema.go
+++ b/pkg/framework/objects/scim_config_token/schema.go
@@ -58,6 +58,10 @@ func (r *scimConfigTokenResource) Schema(
 				Computed:    true,
 				Description: "Timestamp when the token was last used. Null if never used.",
 			},
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/scim_group_partial_permissions/model.go
+++ b/pkg/framework/objects/scim_group_partial_permissions/model.go
@@ -11,6 +11,7 @@ type ScimGroupPartialPermissionsResourceModel struct {
 	ID               types.Int64                       `tfsdk:"id"`
 	GroupID          types.Int64                       `tfsdk:"group_id"`
 	GroupPermissions []ScimGroupPartialPermissionModel `tfsdk:"permissions"`
+	ResourceMetadata types.Dynamic                     `tfsdk:"resource_metadata"`
 }
 
 type ScimGroupPartialPermissionModel struct {

--- a/pkg/framework/objects/scim_group_partial_permissions/schema.go
+++ b/pkg/framework/objects/scim_group_partial_permissions/schema.go
@@ -89,16 +89,20 @@ func (r *scimGroupPartialPermissionsResource) Schema(
 							ElementType: types.StringType,
 							Optional:    true,
 							Description: helper.DocString(
-								`What types of environments to apply Write permissions to. 
-								Even if Write access is restricted to some environment types, the permission set will have Read access to all environments. 
-								The values allowed are ~~~all~~~, ~~~development~~~, ~~~staging~~~, ~~~production~~~ and ~~~other~~~. 
-								Not setting a value is the same as selecting ~~~all~~~. 
+								`What types of environments to apply Write permissions to.
+								Even if Write access is restricted to some environment types, the permission set will have Read access to all environments.
+								The values allowed are ~~~all~~~, ~~~development~~~, ~~~staging~~~, ~~~production~~~ and ~~~other~~~.
+								Not setting a value is the same as selecting ~~~all~~~.
 								Not all permission sets support environment level write settings, only ~~~analyst~~~, ~~~database_admin~~~, ~~~developer~~~, ~~~git_admin~~~ and ~~~team_admin~~~.`,
 							),
 						},
 					},
 				},
 				Optional: true,
+			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
 			},
 		},
 	}

--- a/pkg/framework/objects/scim_group_permissions/model.go
+++ b/pkg/framework/objects/scim_group_permissions/model.go
@@ -11,6 +11,7 @@ type ScimGroupPermissionsResourceModel struct {
 	ID               types.Int64                `tfsdk:"id"`
 	GroupID          types.Int64                `tfsdk:"group_id"`
 	GroupPermissions []ScimGroupPermissionModel `tfsdk:"permissions"`
+	ResourceMetadata types.Dynamic              `tfsdk:"resource_metadata"`
 }
 
 type ScimGroupPermissionModel struct {

--- a/pkg/framework/objects/scim_group_permissions/schema.go
+++ b/pkg/framework/objects/scim_group_permissions/schema.go
@@ -76,16 +76,20 @@ func (r *scimGroupPermissionsResource) Schema(
 							ElementType: types.StringType,
 							Optional:    true,
 							Description: helper.DocString(
-								`What types of environments to apply Write permissions to. 
-								Even if Write access is restricted to some environment types, the permission set will have Read access to all environments. 
-								The values allowed are ~~~all~~~, ~~~development~~~, ~~~staging~~~, ~~~production~~~ and ~~~other~~~. 
-								Not setting a value is the same as selecting ~~~all~~~. 
+								`What types of environments to apply Write permissions to.
+								Even if Write access is restricted to some environment types, the permission set will have Read access to all environments.
+								The values allowed are ~~~all~~~, ~~~development~~~, ~~~staging~~~, ~~~production~~~ and ~~~other~~~.
+								Not setting a value is the same as selecting ~~~all~~~.
 								Not all permission sets support environment level write settings, only ~~~analyst~~~, ~~~database_admin~~~, ~~~developer~~~, ~~~git_admin~~~ and ~~~team_admin~~~.`,
 							),
 						},
 					},
 				},
 				Optional: true,
+			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
 			},
 		},
 	}

--- a/pkg/framework/objects/semantic_layer_configuration/model.go
+++ b/pkg/framework/objects/semantic_layer_configuration/model.go
@@ -5,7 +5,8 @@ import (
 )
 
 type SemanticLayerConfigurationModel struct {
-	ID              types.Int64  `tfsdk:"id"`
-	ProjectID       types.Int64  `tfsdk:"project_id"`
-	EnvironmentID   types.Int64  `tfsdk:"environment_id"`
+	ID               types.Int64   `tfsdk:"id"`
+	ProjectID        types.Int64   `tfsdk:"project_id"`
+	EnvironmentID    types.Int64   `tfsdk:"environment_id"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/semantic_layer_configuration/schema.go
+++ b/pkg/framework/objects/semantic_layer_configuration/schema.go
@@ -31,6 +31,10 @@ func (r *semanticLayerConfigurationResource) Schema(
 				Required:    true,
 				Description: "The ID of the environment",
 			},
+			"resource_metadata": resource_schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/semantic_layer_credential/model.go
+++ b/pkg/framework/objects/semantic_layer_credential/model.go
@@ -17,9 +17,10 @@ type SemanticLayerConfigurationModel struct {
 }
 
 type SnowflakeSLCredentialModel struct {
-	ID            types.Int64                                           `tfsdk:"id"`
-	Configuration SemanticLayerConfigurationModel                       `tfsdk:"configuration"`
-	Credential    snowflake_credential.SnowflakeCredentialResourceModel `tfsdk:"credential"`
+	ID               types.Int64                                           `tfsdk:"id"`
+	Configuration    SemanticLayerConfigurationModel                       `tfsdk:"configuration"`
+	Credential       snowflake_credential.SnowflakeCredentialResourceModel `tfsdk:"credential"`
+	ResourceMetadata types.Dynamic                                         `tfsdk:"resource_metadata"`
 }
 
 type BigQuerySLCredentialModel struct {
@@ -37,22 +38,26 @@ type BigQuerySLCredentialModel struct {
 	AuthProviderCertURL types.String                                        `tfsdk:"auth_provider_x509_cert_url"`
 	ClientCertURL       types.String                                        `tfsdk:"client_x509_cert_url"`
 	ExecutionProject    types.String                                        `tfsdk:"execution_project"`
+	ResourceMetadata    types.Dynamic                                       `tfsdk:"resource_metadata"`
 }
 
 type RedshiftSLCredentialModel struct {
-	ID            types.Int64                                         `tfsdk:"id"`
-	Configuration SemanticLayerConfigurationModel                     `tfsdk:"configuration"`
-	Credential    redshift_credential.RedshiftCredentialResourceModel `tfsdk:"credential"`
+	ID               types.Int64                                         `tfsdk:"id"`
+	Configuration    SemanticLayerConfigurationModel                     `tfsdk:"configuration"`
+	Credential       redshift_credential.RedshiftCredentialResourceModel `tfsdk:"credential"`
+	ResourceMetadata types.Dynamic                                       `tfsdk:"resource_metadata"`
 }
 
 type DatabricksSLCredentialModel struct {
-	ID            types.Int64                                             `tfsdk:"id"`
-	Configuration SemanticLayerConfigurationModel                         `tfsdk:"configuration"`
-	Credential    databricks_credential.DatabricksCredentialResourceModel `tfsdk:"credential"`
+	ID               types.Int64                                             `tfsdk:"id"`
+	Configuration    SemanticLayerConfigurationModel                         `tfsdk:"configuration"`
+	Credential       databricks_credential.DatabricksCredentialResourceModel `tfsdk:"credential"`
+	ResourceMetadata types.Dynamic                                           `tfsdk:"resource_metadata"`
 }
 
 type PostgresSLCredentialModel struct {
-	ID            types.Int64                                             `tfsdk:"id"`
-	Configuration SemanticLayerConfigurationModel                         `tfsdk:"configuration"`
-	Credential    postgres_credential.PostgresCredentialResourceModel 	  `tfsdk:"credential"`
+	ID               types.Int64                                         `tfsdk:"id"`
+	Configuration    SemanticLayerConfigurationModel                     `tfsdk:"configuration"`
+	Credential       postgres_credential.PostgresCredentialResourceModel `tfsdk:"credential"`
+	ResourceMetadata types.Dynamic                                       `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/semantic_layer_credential/schema.go
+++ b/pkg/framework/objects/semantic_layer_credential/schema.go
@@ -49,6 +49,10 @@ var snowflake_sl_credential_resource_schema = resource_schema.Schema{
 			Description: "Snowflake credential details, but used in the context of the Semantic Layer.",
 			Attributes:  snowflake_credential.SnowflakeCredentialResourceSchema.Attributes, // Reuse the schema
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 
@@ -131,6 +135,10 @@ var bigquery_sl_credential_resource_schema = resource_schema.Schema{
 			Optional:    true,
 			Description: "The GCP project that should execute BigQuery jobs for the semantic layer. When not set, jobs will execute in the project associated with the service account.",
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 
@@ -150,6 +158,10 @@ var redshift_sl_credential_resource_schema = resource_schema.Schema{
 			Required:    true,
 			Description: "Redshift credential details, but used in the context of the Semantic Layer.",
 			Attributes:  redshift_credential.RedshiftResourceSchema.Attributes, // Reuse the schema
+		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
 		},
 	},
 }
@@ -171,6 +183,10 @@ var databricks_sl_credential_resource_schema = resource_schema.Schema{
 			Description: "Databricks credential details, but used in the context of the Semantic Layer.",
 			Attributes:  databricks_credential.DatabricksResourceSchema.Attributes, // Reuse the schema
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 
@@ -190,6 +206,10 @@ var postgres_sl_credential_resource_schema = resource_schema.Schema{
 			Required:    true,
 			Description: "Postgres credential details, but used in the context of the Semantic Layer.",
 			Attributes:  postgres_credential.PostgresResourceSchema.Attributes, // Reuse the schema
+		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
 		},
 	},
 }

--- a/pkg/framework/objects/semantic_layer_credential_service_token_mapping/model.go
+++ b/pkg/framework/objects/semantic_layer_credential_service_token_mapping/model.go
@@ -3,8 +3,9 @@ package semantic_layer_credential_service_token_mapping
 import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type SemanticLayerCredentialServiceTokenMapping struct {
-	ID                         types.Int64  `tfsdk:"id"`
-	ProjectID                  types.Int64  `tfsdk:"project_id"`
-	SemanticLayerCredentialID  types.Int64  `tfsdk:"semantic_layer_credential_id"`
-	ServiceTokenID             types.Int64  `tfsdk:"service_token_id"`
+	ID                        types.Int64   `tfsdk:"id"`
+	ProjectID                 types.Int64   `tfsdk:"project_id"`
+	SemanticLayerCredentialID types.Int64   `tfsdk:"semantic_layer_credential_id"`
+	ServiceTokenID            types.Int64   `tfsdk:"service_token_id"`
+	ResourceMetadata          types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/semantic_layer_credential_service_token_mapping/resource.go
+++ b/pkg/framework/objects/semantic_layer_credential_service_token_mapping/resource.go
@@ -77,6 +77,10 @@ func (r *semanticLayerCredentialServiceTokenMappingResource) Schema(_ context.Co
 					int64planmodifier.RequiresReplace(),
 				},
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 	}
 }

--- a/pkg/framework/objects/service_token/model.go
+++ b/pkg/framework/objects/service_token/model.go
@@ -17,6 +17,7 @@ type ServiceTokenResourceModel struct {
 	State       types.Int64  `tfsdk:"state"`
 
 	ServiceTokenPermissions []ServiceTokenPermission `tfsdk:"service_token_permissions"`
+	ResourceMetadata        types.Dynamic            `tfsdk:"resource_metadata"`
 }
 
 type ServiceTokenDataSourceModel struct {

--- a/pkg/framework/objects/service_token/resource.go
+++ b/pkg/framework/objects/service_token/resource.go
@@ -86,6 +86,10 @@ func (st *serviceTokenResource) Schema(_ context.Context, _ resource.SchemaReque
 					int64planmodifier.RequiresReplace(),
 				},
 			},
+			"resource_metadata": schema.DynamicAttribute{
+				Optional:    true,
+				Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+			},
 		},
 		Blocks: map[string]schema.Block{
 			"service_token_permissions": schema.SetNestedBlock{

--- a/pkg/framework/objects/snowflake_credential/model.go
+++ b/pkg/framework/objects/snowflake_credential/model.go
@@ -38,5 +38,6 @@ type SnowflakeCredentialResourceModel struct {
 	PrivateKeyPassphraseWoVersion types.Int64  `tfsdk:"private_key_passphrase_wo_version"`
 	IsActive                      types.Bool   `tfsdk:"is_active"`
 	NumThreads                    types.Int64  `tfsdk:"num_threads"`
-	SemanticLayerCredential       types.Bool   `tfsdk:"semantic_layer_credential"`
+	SemanticLayerCredential       types.Bool    `tfsdk:"semantic_layer_credential"`
+	ResourceMetadata              types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/snowflake_credential/schema.go
+++ b/pkg/framework/objects/snowflake_credential/schema.go
@@ -202,5 +202,9 @@ var SnowflakeCredentialResourceSchema = resource_schema.Schema{
 				snowflake_credential.SemanticLayerCredentialValidator{},
 			},
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }

--- a/pkg/framework/objects/spark_credential/model.go
+++ b/pkg/framework/objects/spark_credential/model.go
@@ -21,5 +21,6 @@ type SparkCredentialResourceModel struct {
 	Token          types.String `tfsdk:"token"`
 	TokenWo        types.String `tfsdk:"token_wo"`
 	TokenWoVersion types.Int64  `tfsdk:"token_wo_version"`
-	Schema         types.String `tfsdk:"schema"`
+	Schema           types.String  `tfsdk:"schema"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/spark_credential/schema.go
+++ b/pkg/framework/objects/spark_credential/schema.go
@@ -98,5 +98,9 @@ var SparkResourceSchema = resource_schema.Schema{
 			Description: "The schema where to create models",
 			Required:    true,
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }

--- a/pkg/framework/objects/starburst_credential/model.go
+++ b/pkg/framework/objects/starburst_credential/model.go
@@ -14,7 +14,8 @@ type StarburstCredentialResourceModel struct {
 	PasswordWo        types.String `tfsdk:"password_wo"`
 	PasswordWoVersion types.Int64  `tfsdk:"password_wo_version"`
 	Database          types.String `tfsdk:"database"`
-	Schema            types.String `tfsdk:"schema"`
+	Schema            types.String  `tfsdk:"schema"`
+	ResourceMetadata  types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 // StarburstCredentialDataSourceModel is the model for the data source

--- a/pkg/framework/objects/starburst_credential/schema.go
+++ b/pkg/framework/objects/starburst_credential/schema.go
@@ -76,6 +76,10 @@ var resourceSchema = resource_schema.Schema{
 				helper.SchemaNameValidator(),
 			},
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/synapse_credential/model.go
+++ b/pkg/framework/objects/synapse_credential/model.go
@@ -20,7 +20,8 @@ type SynapseCredentialResourceModel struct {
 	ClientSecretWoVersion  types.Int64  `tfsdk:"client_secret_wo_version"`
 	Schema                 types.String `tfsdk:"schema"`
 	SchemaAuthorization    types.String `tfsdk:"schema_authorization"`
-	AdapterType            types.String `tfsdk:"adapter_type"`
+	AdapterType            types.String  `tfsdk:"adapter_type"`
+	ResourceMetadata       types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 type SynapseCredentialDataSourceModel struct {

--- a/pkg/framework/objects/synapse_credential/schema.go
+++ b/pkg/framework/objects/synapse_credential/schema.go
@@ -208,6 +208,10 @@ var resourceSchema = resource_schema.Schema{
 				stringvalidator.OneOf("synapse"),
 			},
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/teradata_credential/model.go
+++ b/pkg/framework/objects/teradata_credential/model.go
@@ -17,13 +17,14 @@ type TeradataCredentialDataSourceModel struct {
 
 // TeradataCredentialModel is the model for the resource
 type TeradataCredentialModel struct {
-	ID                types.String `tfsdk:"id"`
-	CredentialID      types.Int64  `tfsdk:"credential_id"`
-	ProjectID         types.Int64  `tfsdk:"project_id"`
-	User              types.String `tfsdk:"user"`
-	Password          types.String `tfsdk:"password"`
-	PasswordWo        types.String `tfsdk:"password_wo"`
-	PasswordWoVersion types.Int64  `tfsdk:"password_wo_version"`
-	Schema            types.String `tfsdk:"schema"`
-	Threads           types.Int64  `tfsdk:"threads"`
+	ID                types.String  `tfsdk:"id"`
+	CredentialID      types.Int64   `tfsdk:"credential_id"`
+	ProjectID         types.Int64   `tfsdk:"project_id"`
+	User              types.String  `tfsdk:"user"`
+	Password          types.String  `tfsdk:"password"`
+	PasswordWo        types.String  `tfsdk:"password_wo"`
+	PasswordWoVersion types.Int64   `tfsdk:"password_wo_version"`
+	Schema            types.String  `tfsdk:"schema"`
+	Threads           types.Int64   `tfsdk:"threads"`
+	ResourceMetadata  types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/teradata_credential/schema.go
+++ b/pkg/framework/objects/teradata_credential/schema.go
@@ -80,6 +80,10 @@ var resourceSchema = resource_schema.Schema{
 			Computed:    true,
 			Default:     int64default.StaticInt64(1),
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/user_groups/model.go
+++ b/pkg/framework/objects/user_groups/model.go
@@ -3,9 +3,10 @@ package user_groups
 import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type UserGroupsResourceModel struct {
-	ID types.String `tfsdk:"id"`
-	UserID types.Int64 `tfsdk:"user_id"`
-	GroupIDs types.Set `tfsdk:"group_ids"` 
+	ID               types.String  `tfsdk:"id"`
+	UserID           types.Int64   `tfsdk:"user_id"`
+	GroupIDs         types.Set     `tfsdk:"group_ids"`
+	ResourceMetadata types.Dynamic `tfsdk:"resource_metadata"`
 }
 
 type UserGroupsDataSourceModel struct {

--- a/pkg/framework/objects/user_groups/schema.go
+++ b/pkg/framework/objects/user_groups/schema.go
@@ -40,6 +40,10 @@ If you would like a different behavior, please open an issue on GitHub. To remov
 			ElementType: types.Int64Type,
 			Required:    true,
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }
 

--- a/pkg/framework/objects/webhook/model.go
+++ b/pkg/framework/objects/webhook/model.go
@@ -18,15 +18,16 @@ type WebhookDataSourceModel struct {
 }
 
 type WebhookResourceModel struct {
-	ID                types.String `tfsdk:"id"`
-	WebhookID         types.String `tfsdk:"webhook_id"`
-	Name              types.String `tfsdk:"name"`
-	Description       types.String `tfsdk:"description"`
-	ClientURL         types.String `tfsdk:"client_url"`
-	EventTypes        types.List   `tfsdk:"event_types"`
-	JobIDs            types.List   `tfsdk:"job_ids"`
-	Active            types.Bool   `tfsdk:"active"`
-	HmacSecret        types.String `tfsdk:"hmac_secret"`
-	HTTPStatusCode    types.String `tfsdk:"http_status_code"`
-	AccountIdentifier types.String `tfsdk:"account_identifier"`
+	ID                types.String  `tfsdk:"id"`
+	WebhookID         types.String  `tfsdk:"webhook_id"`
+	Name              types.String  `tfsdk:"name"`
+	Description       types.String  `tfsdk:"description"`
+	ClientURL         types.String  `tfsdk:"client_url"`
+	EventTypes        types.List    `tfsdk:"event_types"`
+	JobIDs            types.List    `tfsdk:"job_ids"`
+	Active            types.Bool    `tfsdk:"active"`
+	HmacSecret        types.String  `tfsdk:"hmac_secret"`
+	HTTPStatusCode    types.String  `tfsdk:"http_status_code"`
+	AccountIdentifier types.String  `tfsdk:"account_identifier"`
+	ResourceMetadata  types.Dynamic `tfsdk:"resource_metadata"`
 }

--- a/pkg/framework/objects/webhook/schema.go
+++ b/pkg/framework/objects/webhook/schema.go
@@ -122,5 +122,9 @@ var resourceSchema = resource_schema.Schema{
 			Description: "Webhooks Account Identifier",
 			Computed:    true,
 		},
+		"resource_metadata": resource_schema.DynamicAttribute{
+			Optional:    true,
+			Description: "Metadata for tracking resource identity during account migrations. Stored in Terraform state only and not sent to the API.",
+		},
 	},
 }


### PR DESCRIPTION
## Summary
- Adds optional `resource_metadata` attribute of type `Dynamic` to every resource schema and `ResourceModel` struct (56 resource packages)
- Field is persisted in Terraform state only — not sent to the API
- Intended for account migration tooling to track identity mappings between old and new resource IDs across tenancies
- Regenerates docs for all affected resources

Closes #662

🤖 Generated with [Claude Code](https://claude.ai/claude-code)