### PR TITLE
Add git_clone_strategy to repository acceptance tests

### DIFF
--- a/.changes/unreleased/Behind the scenes-20260410-134458.yaml
+++ b/.changes/unreleased/Behind the scenes-20260410-134458.yaml
@@ -1,0 +1,3 @@
+kind: Behind the scenes
+body: Add git_clone_strategy to repository acceptance tests to avoid null constraint violations
+time: 2026-04-10T13:44:58.000000+00:00

--- a/pkg/framework/objects/project_repository/resource_acceptance_test.go
+++ b/pkg/framework/objects/project_repository/resource_acceptance_test.go
@@ -68,6 +68,7 @@ resource "dbtcloud_project" "test_project" {
 resource "dbtcloud_repository" "test_repository" {
   remote_url = "%s"
   project_id = dbtcloud_project.test_project.id
+  git_clone_strategy = "deploy_key"
   depends_on = [dbtcloud_project.test_project]
 }
 
@@ -87,6 +88,7 @@ resource "dbtcloud_project" "test_project" {
 resource "dbtcloud_repository" "test_repository" {
   remote_url = "%s"
   project_id = dbtcloud_project.test_project.id
+  git_clone_strategy = "deploy_key"
   depends_on = [dbtcloud_project.test_project]
 }
 `, projectName, repoUrlGithub)

--- a/pkg/framework/objects/repository/data_source_acceptance_test.go
+++ b/pkg/framework/objects/repository/data_source_acceptance_test.go
@@ -42,6 +42,7 @@ func repositoryDataSourceConfig(projectName, repositoryUrl string) string {
     resource "dbtcloud_repository" "test_repository" {
         project_id = dbtcloud_project.test_project.id
         remote_url = "%s"
+        git_clone_strategy = "deploy_key"
         is_active = true
         depends_on = [
             dbtcloud_project.test_project


### PR DESCRIPTION
## Summary

- Repository acceptance tests in `project_repository` and `repository` (data source) were creating repos without specifying `git_clone_strategy`, which defaults to null
- dbt Cloud's model-layer validation rejects null `git_clone_strategy` during `save()`, producing ~30 staging constraint violations per week
- Adds `git_clone_strategy = "deploy_key"` to match the SSH remote URL these tests use, consistent with the existing `repository/resource_acceptance_test.go` tests that already set it

## Test plan

- [ ] `TestAccDbtCloudProjectRepositoryResource` passes against staging
- [ ] `TestAccDbtCloudRepositoryDataSource` passes against staging
- [ ] Staging constraint violation count for `git_clone_strategy null` drops to 0 after next test run

🤖 Generated with Claude Code 🤖