### PR TITLE
feat(environment_variable): detect changes to env vars in remote

### DIFF
--- a/.changes/unreleased/Changes-20260430-151347.yaml
+++ b/.changes/unreleased/Changes-20260430-151347.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: Detect dbt env var changes and apply when drift is detected
+time: 2026-04-30T15:13:47.915175-05:00

--- a/pkg/framework/objects/environment_variable/resource.go
+++ b/pkg/framework/objects/environment_variable/resource.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -156,6 +157,46 @@ func (r *environmentVariableResource) Read(
 
 	// Refresh state values
 	state.ID = types.StringValue(fmt.Sprintf("%d:%s", projectID, envVar.Name))
+
+	isSecret := strings.HasPrefix(envVar.Name, "DBT_ENV_SECRET_") ||
+		strings.HasPrefix(envVar.Name, "DBT_SECRET_")
+
+	if !isSecret {
+		// Non-secret: sync full values from API to detect drift.
+		envVarElements := make(map[string]attr.Value)
+		for key, value := range envVar.EnvironmentNameValues {
+			envVarElements[key] = types.StringValue(value.Value)
+		}
+		envVarMap, d := types.MapValue(types.StringType, envVarElements)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.EnvironmentValues = envVarMap
+	} else {
+		// Secret: API masks values so we can't sync them, but we can still detect
+		// structural changes (environments added/removed) by reconciling the key
+		// set from the API against the preserved values from state.
+		existingValues := state.EnvironmentValues.Elements()
+		envVarElements := make(map[string]attr.Value)
+		for key := range envVar.EnvironmentNameValues {
+			if existing, ok := existingValues[key]; ok {
+				// Keep the known plaintext value for environments that still exist.
+				envVarElements[key] = existing
+			} else {
+				// New environment appeared in API that we have no state value for.
+				envVarElements[key] = types.StringValue("")
+			}
+		}
+		// Keys present in state but absent from API have been removed — omitting
+		// them here causes Terraform to surface the drift.
+		envVarMap, d := types.MapValue(types.StringType, envVarElements)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.EnvironmentValues = envVarMap
+	}
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)

--- a/pkg/framework/objects/environment_variable/resource.go
+++ b/pkg/framework/objects/environment_variable/resource.go
@@ -158,8 +158,7 @@ func (r *environmentVariableResource) Read(
 	// Refresh state values
 	state.ID = types.StringValue(fmt.Sprintf("%d:%s", projectID, envVar.Name))
 
-	isSecret := strings.HasPrefix(envVar.Name, "DBT_ENV_SECRET_") ||
-		strings.HasPrefix(envVar.Name, "DBT_SECRET_")
+	isSecret := strings.HasPrefix(envVar.Name, "DBT_ENV_SECRET")
 
 	if !isSecret {
 		// Non-secret: sync full values from API to detect drift.

--- a/pkg/framework/objects/environment_variable/resource_acceptance_test.go
+++ b/pkg/framework/objects/environment_variable/resource_acceptance_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -49,7 +50,7 @@ func TestAccDbtCloudEnvironmentVariableResourceSecret(t *testing.T) {
 		CheckDestroy:             testAccCheckDbtCloudEnvironmentVariableDestroy,
 		Steps: []resource.TestStep{
 			getSecretEnvTestStep(projectName, environmentName, environmentVariableName),
-			getImportTestStep(),
+			getImportTestStepSecret(),
 		},
 	})
 }
@@ -70,6 +71,17 @@ func TestAccDbtCloudEnvironmentVariableResourceModify(t *testing.T) {
 }
 
 func getImportTestStep() resource.TestStep {
+	return resource.TestStep{
+		ResourceName:      "dbtcloud_environment_variable.test_env_var",
+		ImportState:       true,
+		ImportStateVerify: true,
+		// environment_values is now readable from the API for non-secret vars.
+	}
+}
+
+// getImportTestStepSecret ignores environment_values on import because the API
+// masks secret values and cannot round-trip them.
+func getImportTestStepSecret() resource.TestStep {
 	return resource.TestStep{
 		ResourceName:            "dbtcloud_environment_variable.test_env_var",
 		ImportState:             true,
@@ -241,6 +253,83 @@ resource "dbtcloud_environment_variable" "test_env_var" {
   ]
 }
 `, projectName, environmentName, acctest_config.DBT_CLOUD_VERSION, environmentVariableName, environmentName)
+}
+
+// TestAccDbtCloudEnvironmentVariableResourceDrift verifies that changes made to a
+// non-secret env var outside of Terraform (e.g. via the dbt Cloud UI) are detected
+// as drift on the next plan.
+func TestAccDbtCloudEnvironmentVariableResourceDrift(t *testing.T) {
+	projectName, environmentName, environmentVariableName := getTestInputData()
+
+	var capturedProjectID int
+	var capturedEnvVarName string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudEnvironmentVariableDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: create the resource and capture its project ID and name for use in PreConfig.
+			{
+				Config: testAccDbtCloudEnvironmentVariableResourceBasicConfig(
+					projectName,
+					environmentName,
+					environmentVariableName,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						rs := s.RootModule().Resources["dbtcloud_environment_variable.test_env_var"]
+						parts := strings.Split(rs.Primary.ID, dbt_cloud.ID_DELIMITER)
+						var err error
+						capturedProjectID, err = strconv.Atoi(parts[0])
+						if err != nil {
+							return fmt.Errorf("could not parse project ID from %s", rs.Primary.ID)
+						}
+						capturedEnvVarName = parts[1]
+						return nil
+					},
+				),
+			},
+			// Step 2: change values out-of-band via the API, then assert the plan is non-empty
+			// (drift detected). Applying the step also restores the original values.
+			{
+				PreConfig: func() {
+					client, err := acctest_helper.SharedClient()
+					if err != nil {
+						panic(fmt.Sprintf("could not get shared client: %s", err))
+					}
+					envVar, err := client.GetEnvironmentVariable(capturedProjectID, capturedEnvVarName)
+					if err != nil {
+						panic(fmt.Sprintf("could not read env var for out-of-band change: %s", err))
+					}
+					envValuesMap := make(map[string]string)
+					for _, v := range envVar.EnvironmentNameValues {
+						envValuesMap[strconv.Itoa(v.ID)] = "OutOfBandValue"
+					}
+					if _, err := client.UpdateEnvironmentVariable(
+						capturedProjectID,
+						dbt_cloud.AbstractedEnvironmentVariable{
+							Name:              capturedEnvVarName,
+							ProjectID:         capturedProjectID,
+							EnvironmentValues: envValuesMap,
+						},
+					); err != nil {
+						panic(fmt.Sprintf("out-of-band env var update failed: %s", err))
+					}
+				},
+				Config: testAccDbtCloudEnvironmentVariableResourceBasicConfig(
+					projectName,
+					environmentName,
+					environmentVariableName,
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
 }
 
 func testAccCheckDbtCloudEnvironmentVariableExists(resource string) resource.TestCheckFunc {


### PR DESCRIPTION
## Problem

The `dbtcloud_environment_variable` resource's `Read` function was calling the dbt Cloud API but only using the response to refresh the resource `id` — it silently discarded the returned `environment_values`. This meant Terraform state always reflected the last-applied config values, making drift detection impossible. Changes made outside of Terraform (e.g. via the dbt Cloud UI) would never surface in a subsequent `terraform plan`.

## Changes

### Drift detection for non-secret env vars

`Read` now populates `state.EnvironmentValues` from the API response. On the next `terraform plan`, Terraform compares the refreshed state against config and surfaces any out-of-band changes as drift.

### Structural drift detection for secret env vars (`DBT_ENV_SECRET`)

The dbt Cloud API masks values for secret env vars, so raw value sync isn't possible. However, the API does return the key structure (which environments the var is defined for). `Read` now reconciles the API key set against the preserved state values:

- Environments removed from dbt Cloud → key dropped from state → drift surfaced on next plan
- Environments added in dbt Cloud → key added to state with empty string → drift surfaced on next plan
- Value changed in dbt Cloud → undetectable (fundamental API limitation — masked values can't be compared)

### Drift detection coverage

| Change type | Non-secret | Secret |
|---|---|---|
| Value changed outside Terraform | ✅ detected | ❌ API masks value |
| Environment key removed | ✅ detected | ✅ detected (key gone from API) |
| Environment key added | ✅ detected | ✅ detected (empty string surfaced) |
| Config value changed | ✅ detected | ✅ detected (state vs config diff) |

### Tests

- `TestAccDbtCloudEnvironmentVariableResourceDrift` — creates a non-secret env var, changes its values out-of-band via the API using `PreConfig`, then asserts `plancheck.ExpectNonEmptyPlan()` before the apply corrects the drift
- `getImportTestStep` — removed `environment_values` from `ImportStateVerifyIgnore` since non-secret values now round-trip correctly through import
- `getImportTestStepSecret` — new helper that retains the ignore for secret vars, used by `TestAccDbtCloudEnvironmentVariableResourceSecret`