### PR TITLE
Add set up terraform step to goreleaser

### DIFF
--- a/.changes/unreleased/Behind the scenes-20260507-085535.yaml
+++ b/.changes/unreleased/Behind the scenes-20260507-085535.yaml
@@ -1,0 +1,3 @@
+kind: Behind the scenes
+body: Add set up terraform step to goreleaser
+time: 2026-05-07T08:55:35.438267+03:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269ef065 # hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # goreleaser/goreleaser-action@v5
         with:


### PR DESCRIPTION
HashiCorp's GPG signing key expired on 2026-04-18, causing go generate ./... to fail during release. The root cause is tfplugindocs using hc-install to auto-download Terraform at runtime — versions of hc-install ≤ v0.9.3 have the expired key embedded, so signature verification fails before the binary is unpacked.

Fix: Add hashicorp/setup-terraform@v3 to the release workflow before GoReleaser runs. When Terraform is already on PATH, tfplugindocs uses it directly and skips the broken download path entirely.