### PR TITLE
feat(group): support notification_manager permission_set (#692)

### DIFF
--- a/.changes/unreleased/Changes-20260522-172253.yaml
+++ b/.changes/unreleased/Changes-20260522-172253.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: Allow `notification_manager` as a `permission_set` value on `dbtcloud_group`, `dbtcloud_group_partial_permissions`, `dbtcloud_scim_group_permissions`, `dbtcloud_scim_group_partial_permissions`, and `dbtcloud_service_token` (resolves #692)
+time: 2026-05-22T17:22:53.000000+00:00

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -29,6 +29,7 @@ The mapping of permission names [from the docs](https://docs.getdbt.com/docs/clo
 |Manage marketplace apps | manage_marketplace_apps|
 |Member | member|
 |Metadata Only | metadata_only|
+|Notification Manager | notification_manager|
 |Owner | owner|
 |Project Creator | project_creator|
 |Read-Only | readonly|

--- a/docs/resources/service_token.md
+++ b/docs/resources/service_token.md
@@ -29,6 +29,7 @@ The mapping of permission names [from the docs](https://docs.getdbt.com/docs/clo
 |Manage marketplace apps | manage_marketplace_apps|
 |Member | member|
 |Metadata Only | metadata_only|
+|Notification Manager | notification_manager|
 |Owner | owner|
 |Project Creator | project_creator|
 |Read-Only | readonly|

--- a/pkg/dbt_cloud/common.go
+++ b/pkg/dbt_cloud/common.go
@@ -42,6 +42,7 @@ var (
 		"cost_management_viewer",
 		"cost_management_admin",
 		"manage_marketplace_apps",
+		"notification_manager",
 	}
 )
 

--- a/templates/resources/group.md.tmpl
+++ b/templates/resources/group.md.tmpl
@@ -36,6 +36,7 @@ The mapping of permission names [from the docs](https://docs.getdbt.com/docs/clo
 |Manage marketplace apps | manage_marketplace_apps|
 |Member | member|
 |Metadata Only | metadata_only|
+|Notification Manager | notification_manager|
 |Owner | owner|
 |Project Creator | project_creator|
 |Read-Only | readonly|

--- a/templates/resources/service_token.md.tmpl
+++ b/templates/resources/service_token.md.tmpl
@@ -37,6 +37,7 @@ The mapping of permission names [from the docs](https://docs.getdbt.com/docs/clo
 |Manage marketplace apps | manage_marketplace_apps|
 |Member | member|
 |Metadata Only | metadata_only|
+|Notification Manager | notification_manager|
 |Owner | owner|
 |Project Creator | project_creator|
 |Read-Only | readonly|


### PR DESCRIPTION
## Summary

- Adds `notification_manager` to the allowed `permission_set` values, so it can be assigned via `dbtcloud_group`, `dbtcloud_group_partial_permissions`, `dbtcloud_scim_group_permissions`, `dbtcloud_scim_group_partial_permissions`, and `dbtcloud_service_token`
- Updates the permission-mapping tables in the `dbtcloud_group` and `dbtcloud_service_token` docs (templates + regenerated `docs/`)
- Adds a changie entry under `.changes/unreleased`

## Why

The dbt Cloud backend added the `notification_manager` permission set in [dbt-cloud#17425](https://github.com/dbt-labs/dbt-cloud/pull/17425). The provider was rejecting it at validation time, blocking IaC management of a permission that is already configurable via the UI (Enterprise Settings → Groups & Licence → Permission set). Reported in #692.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/dbt_cloud/... ./pkg/framework/objects/group/... ./pkg/framework/objects/service_token/... ./pkg/framework/objects/group_partial_permissions/... ./pkg/framework/objects/scim_group_permissions/... ./pkg/framework/objects/scim_group_partial_permissions/...`
- [x] `go generate ./...` — confirmed only the two expected doc files changed
- [ ] CI green
- [ ] Manual: apply a `dbtcloud_group` with `permission_set = "notification_manager"` against a dbt Cloud account that has the permission enabled

Resolves #692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)