### PR TITLE
ZEI: Webhooks - Add archived webhook resurrection behavior to Webhook resource

### DIFF
--- a/.changes/unreleased/Changes-20260525-164222.yaml
+++ b/.changes/unreleased/Changes-20260525-164222.yaml
@@ -1,3 +1,3 @@
 kind: Changes
-body: when updating clienturl on an inactive webhook, expect input from api
+body: When `client_url` changes on an inactive webhook, accept the reactivated state returned by the dbt Cloud API.
 time: 2026-05-25T16:42:22.059809+03:00

--- a/.changes/unreleased/Changes-20260525-164222.yaml
+++ b/.changes/unreleased/Changes-20260525-164222.yaml
@@ -1,3 +1,3 @@
 kind: Changes
-body: When `client_url` changes on an inactive webhook, accept the reactivated state returned by the dbt Cloud API.
+body: Error at plan time when `client_url` changes on an inactive webhook; users must set `active = true` to acknowledge that the dbt Cloud API will reactivate it.
 time: 2026-05-25T16:42:22.059809+03:00

--- a/.changes/unreleased/Changes-20260525-164222.yaml
+++ b/.changes/unreleased/Changes-20260525-164222.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: when updating clienturl on an inactive webhook, expect input from api
+time: 2026-05-25T16:42:22.059809+03:00

--- a/pkg/framework/objects/webhook/resource.go
+++ b/pkg/framework/objects/webhook/resource.go
@@ -288,9 +288,9 @@ func (r *webhookResource) ModifyPlan(
 	}
 
 	// The dbt Cloud API reactivates an inactive webhook when its client_url
-	// changes. If the plan still expects active=false, mark it as unknown so
-	// Terraform accepts the post-apply value returned by the API instead of
-	// raising an inconsistent-result error.
+	// changes, which would produce an inconsistent-result error if the plan
+	// still expects active=false. Error at plan time and instruct the user to
+	// also set active=true in their configuration.
 	if state.Active.IsNull() || state.Active.IsUnknown() || state.Active.ValueBool() {
 		return
 	}
@@ -303,12 +303,11 @@ func (r *webhookResource) ModifyPlan(
 	if plan.Active.IsNull() || plan.Active.IsUnknown() || plan.Active.ValueBool() {
 		return
 	}
-	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("active"), types.BoolUnknown())...)
-	resp.Diagnostics.AddAttributeWarning(
+	resp.Diagnostics.AddAttributeError(
 		path.Root("active"),
-		"Webhook will be reactivated",
+		"Cannot change client_url while active=false",
 		"The dbt Cloud API automatically reactivates an inactive webhook when its client_url changes. "+
-			"The 'active' attribute will be set to true after apply, regardless of the configured value.",
+			"Set 'active = true' in your configuration to change the client_url.",
 	)
 }
 

--- a/pkg/framework/objects/webhook/resource.go
+++ b/pkg/framework/objects/webhook/resource.go
@@ -288,8 +288,9 @@ func (r *webhookResource) ModifyPlan(
 	}
 
 	// The dbt Cloud API reactivates an inactive webhook when its client_url
-	// changes. Mark active as unknown so Terraform accepts the post-apply value
-	// returned by the API instead of raising an inconsistent-result error.
+	// changes. If the plan still expects active=false, mark it as unknown so
+	// Terraform accepts the post-apply value returned by the API instead of
+	// raising an inconsistent-result error.
 	if state.Active.IsNull() || state.Active.IsUnknown() || state.Active.ValueBool() {
 		return
 	}
@@ -297,6 +298,9 @@ func (r *webhookResource) ModifyPlan(
 		return
 	}
 	if plan.ClientURL.Equal(state.ClientURL) {
+		return
+	}
+	if plan.Active.IsNull() || plan.Active.IsUnknown() || plan.Active.ValueBool() {
 		return
 	}
 	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("active"), types.BoolUnknown())...)

--- a/pkg/framework/objects/webhook/resource.go
+++ b/pkg/framework/objects/webhook/resource.go
@@ -16,6 +16,7 @@ var (
 	_ resource.Resource                = &webhookResource{}
 	_ resource.ResourceWithConfigure   = &webhookResource{}
 	_ resource.ResourceWithImportState = &webhookResource{}
+	_ resource.ResourceWithModifyPlan  = &webhookResource{}
 )
 
 func WebhookResource() resource.Resource {
@@ -266,6 +267,37 @@ func (r *webhookResource) Update(
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+}
+
+func (r *webhookResource) ModifyPlan(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+) {
+	// Skip on resource creation or deletion
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan, state WebhookResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// The dbt Cloud API reactivates an inactive webhook when its client_url
+	// changes. Mark active as unknown so Terraform accepts the post-apply value
+	// returned by the API instead of raising an inconsistent-result error.
+	if !state.Active.ValueBool() && plan.ClientURL != state.ClientURL {
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("active"), types.BoolUnknown())...)
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("active"),
+			"Webhook will be reactivated",
+			"The dbt Cloud API automatically reactivates an inactive webhook when its client_url changes. "+
+				"The 'active' attribute will be set to true after apply, regardless of the configured value.",
+		)
 	}
 }
 

--- a/pkg/framework/objects/webhook/resource.go
+++ b/pkg/framework/objects/webhook/resource.go
@@ -290,15 +290,22 @@ func (r *webhookResource) ModifyPlan(
 	// The dbt Cloud API reactivates an inactive webhook when its client_url
 	// changes. Mark active as unknown so Terraform accepts the post-apply value
 	// returned by the API instead of raising an inconsistent-result error.
-	if !state.Active.ValueBool() && plan.ClientURL != state.ClientURL {
-		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("active"), types.BoolUnknown())...)
-		resp.Diagnostics.AddAttributeWarning(
-			path.Root("active"),
-			"Webhook will be reactivated",
-			"The dbt Cloud API automatically reactivates an inactive webhook when its client_url changes. "+
-				"The 'active' attribute will be set to true after apply, regardless of the configured value.",
-		)
+	if state.Active.IsNull() || state.Active.IsUnknown() || state.Active.ValueBool() {
+		return
 	}
+	if plan.ClientURL.IsNull() || plan.ClientURL.IsUnknown() {
+		return
+	}
+	if plan.ClientURL.Equal(state.ClientURL) {
+		return
+	}
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("active"), types.BoolUnknown())...)
+	resp.Diagnostics.AddAttributeWarning(
+		path.Root("active"),
+		"Webhook will be reactivated",
+		"The dbt Cloud API automatically reactivates an inactive webhook when its client_url changes. "+
+			"The 'active' attribute will be set to true after apply, regardless of the configured value.",
+	)
 }
 
 func (r *webhookResource) Delete(

--- a/pkg/framework/objects/webhook/resource_acceptance_test.go
+++ b/pkg/framework/objects/webhook/resource_acceptance_test.go
@@ -92,11 +92,14 @@ var modifyConfigTestStep = resource.TestStep{
 	),
 }
 
-// resurrectionConfigTestStep exercises the ModifyPlan behavior: changing
-// client_url on an inactive webhook causes the dbt Cloud API to reactivate it.
-// The plan should accept active becoming true after apply.
-var resurrectionConfigTestStep = resource.TestStep{
-	Config: testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, "https://example.com/resurrected", "true"),
+// resurrectionDriftTestStep exercises the ModifyPlan unknown-marking branch:
+// config keeps active=false while changing client_url, so the dbt Cloud API
+// reactivates the webhook server-side. Apply must succeed (no inconsistent
+// result) and the post-apply state must show active=true. The plan stays
+// non-empty afterward because config still disagrees with the live value.
+var resurrectionDriftTestStep = resource.TestStep{
+	Config:             testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, "https://example.com/resurrected", "false"),
+	ExpectNonEmptyPlan: true,
 	Check: resource.ComposeTestCheckFunc(
 		testAccCheckDbtCloudWebhookExists("dbtcloud_webhook.test_webhook"),
 		resource.TestCheckResourceAttr(
@@ -104,6 +107,20 @@ var resurrectionConfigTestStep = resource.TestStep{
 			"client_url",
 			"https://example.com/resurrected",
 		),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_webhook.test_webhook",
+			"active",
+			"true",
+		),
+	),
+}
+
+// resurrectionConvergeTestStep flips the config to match the live value
+// (active=true) so the test ends with a clean plan before ImportState runs.
+var resurrectionConvergeTestStep = resource.TestStep{
+	Config: testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, "https://example.com/resurrected", "true"),
+	Check: resource.ComposeTestCheckFunc(
+		testAccCheckDbtCloudWebhookExists("dbtcloud_webhook.test_webhook"),
 		resource.TestCheckResourceAttr(
 			"dbtcloud_webhook.test_webhook",
 			"active",
@@ -130,7 +147,8 @@ func TestAccDbtCloudWebhookResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			basicConfigTestStep,
 			modifyConfigTestStep,
-			resurrectionConfigTestStep,
+			resurrectionDriftTestStep,
+			resurrectionConvergeTestStep,
 			importStateTestStep,
 		},
 	})

--- a/pkg/framework/objects/webhook/resource_acceptance_test.go
+++ b/pkg/framework/objects/webhook/resource_acceptance_test.go
@@ -53,7 +53,7 @@ var basicConfigTestStep = resource.TestStep{
 }
 
 var modifyConfigTestStep = resource.TestStep{
-	Config: testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, active),
+	Config: testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, "https://example.com/test", active),
 	Check: resource.ComposeTestCheckFunc(
 		testAccCheckDbtCloudWebhookExists("dbtcloud_webhook.test_webhook"),
 		resource.TestCheckResourceAttr(
@@ -92,6 +92,26 @@ var modifyConfigTestStep = resource.TestStep{
 	),
 }
 
+// resurrectionConfigTestStep exercises the ModifyPlan behavior: changing
+// client_url on an inactive webhook causes the dbt Cloud API to reactivate it.
+// The plan should accept active becoming true after apply.
+var resurrectionConfigTestStep = resource.TestStep{
+	Config: testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, "https://example.com/resurrected", "true"),
+	Check: resource.ComposeTestCheckFunc(
+		testAccCheckDbtCloudWebhookExists("dbtcloud_webhook.test_webhook"),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_webhook.test_webhook",
+			"client_url",
+			"https://example.com/resurrected",
+		),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_webhook.test_webhook",
+			"active",
+			"true",
+		),
+	),
+}
+
 func TestAccDbtCloudWebhookResource(t *testing.T) {
 	importStateTestStep := resource.TestStep{
 		ResourceName:      "dbtcloud_webhook.test_webhook",
@@ -110,6 +130,7 @@ func TestAccDbtCloudWebhookResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			basicConfigTestStep,
 			modifyConfigTestStep,
+			resurrectionConfigTestStep,
 			importStateTestStep,
 		},
 	})
@@ -133,7 +154,7 @@ resource "dbtcloud_webhook" "test_webhook" {
 `, projectName, webhookName)
 }
 
-func testAccDbtCloudWebhookResourceFullConfig(webhookName, projectName, active string) string {
+func testAccDbtCloudWebhookResourceFullConfig(webhookName, projectName, clientURL, active string) string {
 	return fmt.Sprintf(`
 resource "dbtcloud_project" "test_project" {
   name        = "%s"
@@ -165,14 +186,14 @@ resource "dbtcloud_job" "test" {
 resource "dbtcloud_webhook" "test_webhook" {
 	name = "%s"
 	description = "My webhook"
-	client_url = "https://example.com/test"
+	client_url = "%s"
 	event_types = [
 	  "job.run.completed"
 	]
 	job_ids = [dbtcloud_job.test.id]
 	active = "%s"
   }
-`, projectName, acctest_config.DBT_CLOUD_VERSION, webhookName, active)
+`, projectName, acctest_config.DBT_CLOUD_VERSION, webhookName, clientURL, active)
 }
 
 func testAccCheckDbtCloudWebhookExists(resource string) resource.TestCheckFunc {

--- a/pkg/framework/objects/webhook/resource_acceptance_test.go
+++ b/pkg/framework/objects/webhook/resource_acceptance_test.go
@@ -92,14 +92,19 @@ var modifyConfigTestStep = resource.TestStep{
 	),
 }
 
-// resurrectionDriftTestStep exercises the ModifyPlan unknown-marking branch:
-// config keeps active=false while changing client_url, so the dbt Cloud API
-// reactivates the webhook server-side. Apply must succeed (no inconsistent
-// result) and the post-apply state must show active=true. The plan stays
-// non-empty afterward because config still disagrees with the live value.
-var resurrectionDriftTestStep = resource.TestStep{
-	Config:             testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, "https://example.com/resurrected", "false"),
-	ExpectNonEmptyPlan: true,
+// resurrectionPlanErrorTestStep verifies that changing client_url on an
+// inactive webhook while keeping active=false fails at plan time with a
+// clear error, because the dbt Cloud API would reactivate the webhook and
+// produce an inconsistent result.
+var resurrectionPlanErrorTestStep = resource.TestStep{
+	Config:      testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, "https://example.com/resurrected", "false"),
+	ExpectError: regexp.MustCompile(`Cannot change client_url while active=false`),
+}
+
+// resurrectionConvergeTestStep is the happy path: the user opts into
+// reactivation by setting active=true alongside the client_url change.
+var resurrectionConvergeTestStep = resource.TestStep{
+	Config: testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, "https://example.com/resurrected", "true"),
 	Check: resource.ComposeTestCheckFunc(
 		testAccCheckDbtCloudWebhookExists("dbtcloud_webhook.test_webhook"),
 		resource.TestCheckResourceAttr(
@@ -107,20 +112,6 @@ var resurrectionDriftTestStep = resource.TestStep{
 			"client_url",
 			"https://example.com/resurrected",
 		),
-		resource.TestCheckResourceAttr(
-			"dbtcloud_webhook.test_webhook",
-			"active",
-			"true",
-		),
-	),
-}
-
-// resurrectionConvergeTestStep flips the config to match the live value
-// (active=true) so the test ends with a clean plan before ImportState runs.
-var resurrectionConvergeTestStep = resource.TestStep{
-	Config: testAccDbtCloudWebhookResourceFullConfig(webhookName2, projectName, "https://example.com/resurrected", "true"),
-	Check: resource.ComposeTestCheckFunc(
-		testAccCheckDbtCloudWebhookExists("dbtcloud_webhook.test_webhook"),
 		resource.TestCheckResourceAttr(
 			"dbtcloud_webhook.test_webhook",
 			"active",
@@ -147,7 +138,7 @@ func TestAccDbtCloudWebhookResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			basicConfigTestStep,
 			modifyConfigTestStep,
-			resurrectionDriftTestStep,
+			resurrectionPlanErrorTestStep,
 			resurrectionConvergeTestStep,
 			importStateTestStep,
 		},


### PR DESCRIPTION
Problem:
A new behavior that resurrects previously archived webhook subscriptions when `webhook_url` gets changed is being introduced in [dbt-cloud](https://github.com/dbt-labs/dbt-cloud/pull/17661). This behavior results in the provider seeing unexpected changes in the `is_active` field.

Solution:
Mark active as unknown if the `ClientURL` field is modified, for the field to consider the API response as the new source of truth. Also added an error message so users aren't taken by surprise by the change.