### PR TITLE
fix(client): actually retry transient 5xx and 429 responses (#695)

### DIFF
--- a/.changes/unreleased/Fixes-20260526-210625.yaml
+++ b/.changes/unreleased/Fixes-20260526-210625.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: API client now actually retries transient HTTP failures (500, 502, 503, 504, 408, 429 and any user-configured `retriable_status_codes`). Previously `doRequestWithRetry` short-circuited every non-2xx response with an early return before the retry/backoff branch could fire, so transient `cloud.getdbt.com` 5xx responses surfaced as one-shot Terraform diagnostics on the first attempt. Network/transport-level errors are now retried as well (resolves #695).
+time: 2026-05-26T21:06:25.000000+00:00

--- a/pkg/dbt_cloud/client.go
+++ b/pkg/dbt_cloud/client.go
@@ -178,114 +178,172 @@ func NewClient(account_id *int64, token *string, host_url *string, maxRetries *i
 	return &c, nil
 }
 
-func (c *Client) doRequestWithRetry(req *http.Request) ([]byte, error) {
-	var err error
+// defaultRetriableHTTPCodes lists the HTTP status codes the client retries by
+// default when the provider has not supplied an explicit retriable_status_codes
+// list. They cover the transient upstream / proxy / rate-limit failures that
+// have caused real customer apply errors and post-merge CI flakes:
+//
+//   - 408 Request Timeout
+//   - 429 Too Many Requests
+//   - 500 Internal Server Error
+//   - 502 Bad Gateway
+//   - 503 Service Unavailable
+//   - 504 Gateway Timeout
+//
+// 501 Not Implemented is intentionally excluded because it indicates a
+// permanent missing feature rather than a transient failure.
+var defaultRetriableHTTPCodes = []int{408, 429, 500, 502, 503, 504}
 
-	// This is needed in case the provider code wants to do retries but the provider config is set to disable retries
+func (c *Client) doRequestWithRetry(req *http.Request) ([]byte, error) {
+	// Provider config may want to disable retries even when client code asks
+	// for them. Floor MaxRetries at 1 so we always make at least one attempt.
 	if c.DisableRetry || c.MaxRetries <= 0 {
 		c.MaxRetries = 1
 	}
 
 	setRequestHeaders(req, c.Token)
 
-	for i := 0; i < c.MaxRetries; i++ {
-		res, err := c.HTTPClient.Do(req)
-		if err != nil {
-			return nil, err
-		}
-
-		defer res.Body.Close()
-
-		body, err := io.ReadAll(res.Body)
-
-		// Handle 404 errors - check if it's a true not found or a permissions issue
-		if res.StatusCode == 404 {
-			isResourceNotFound, apiErr, parseErr := parseAPIError(body)
-			if parseErr != nil {
-				// If we can't parse the error, return a generic 404
-				return nil, fmt.Errorf("resource-not-found (status 404): URL: %s, Response: %s", req.URL, body)
-			}
-
-			if isResourceNotFound {
-				// Check if the error message mentions permissions - this is a common pattern in dbt Cloud API
-				userMsg := strings.ToLower(apiErr.Status.UserMessage)
-				if strings.Contains(userMsg, "permission") || strings.Contains(userMsg, "proper permissions") {
-					return nil, fmt.Errorf("resource-not-found-permissions: The resource was not found, but this may be due to insufficient permissions. The API token may not have access to this resource or the environment it belongs to.\n\nStatus: 404\nURL: %s\nMessage: %s", req.URL, apiErr.Status.UserMessage)
-				}
-
-				// For GET requests or DELETE operations, this is typically a legitimate not-found
-				// (DELETE gets 404 when resource already deleted, which is fine)
-				if req.Method == "GET" || req.Method == "DELETE" {
-					return nil, fmt.Errorf("resource-not-found: %s", req.URL)
-				}
-
-				// For POST/PUT on non-permission 404s, provide additional context
-				// This helps with update/create operations that fail due to permissions
-				return nil, fmt.Errorf("resource-not-found: The resource was not found. If you are updating a resource, this may indicate insufficient permissions.\n\nStatus: 404\nURL: %s\nMessage: %s", req.URL, apiErr.Status.UserMessage)
-			}
-		}
-
-		if res.StatusCode == 400 {
-			return nil, fmt.Errorf("resource-not-found: %s", body)
-		}
-
-		// Handle permission errors (401 Unauthorized, 403 Forbidden)
-		if res.StatusCode == 401 {
-			return nil, fmt.Errorf("unauthorized: The API token does not have permission to access this resource. Status: 401, URL: %s, Response: %s", req.URL, body)
-		}
-
-		if res.StatusCode == 403 {
-			return nil, fmt.Errorf("forbidden: The API token does not have permission to perform this action. This may be due to environment-level permissions or other access restrictions. Status: 403, URL: %s, Response: %s", req.URL, body)
-		}
-
-		if res.StatusCode == 500 {
-			return nil, fmt.Errorf("internal-server-error: %s", body)
-		}
-
-		// Check for other non-2xx status codes
-		if res.StatusCode < 200 || res.StatusCode >= 300 {
-			return nil, fmt.Errorf("unexpected status code %d: %s, URL: %s", res.StatusCode, body, req.URL)
-		}
-
-		if err == nil {
+	var lastErr error
+	for attempt := 0; attempt < c.MaxRetries; attempt++ {
+		body, statusCode, attemptErr := c.attemptRequest(req)
+		if attemptErr == nil {
 			return body, nil
-		} else {
-			if isErrorRetriable(res.StatusCode, c.RetriableStatusCodes) {
-				waitDuration := time.Duration(c.RetryIntervalSeconds) * time.Second
-				// Exponential backoff
-				if i > 0 {
-					waitDuration = time.Duration(c.RetryIntervalSeconds) * time.Second * (1 << i) // Exponential backoff
-					fmt.Printf("Waiting for %v before retrying...\n", waitDuration)
-					time.Sleep(waitDuration)
-				} else {
-					// Linear backoff for the first retry
-					fmt.Printf("Waiting for %d seconds before retrying...\n", c.RetryIntervalSeconds)
-					time.Sleep(waitDuration)
-				}
-				continue
-			}
+		}
+		lastErr = attemptErr
 
-			if strings.Contains(err.Error(), "resource-not-found") {
-				return nil, err
-			}
+		attemptsRemaining := c.MaxRetries - 1 - attempt
+
+		// Transport-level failures (statusCode == 0: DNS, connection reset,
+		// timeout) and HTTP responses listed in retriable_status_codes /
+		// defaultRetriableHTTPCodes are retried with exponential backoff.
+		// Everything else surfaces immediately so callers see the same
+		// terminal error they did before this fix.
+		retriable := statusCode == 0 ||
+			isHTTPCodeRetriable(statusCode, c.RetriableStatusCodes)
+
+		if !retriable || attemptsRemaining == 0 {
+			return nil, attemptErr
 		}
 
-		return nil, err
+		waitDuration := time.Duration(c.RetryIntervalSeconds) * time.Second
+		if attempt > 0 {
+			// Exponential backoff after the first retry.
+			waitDuration = time.Duration(c.RetryIntervalSeconds) * time.Second * (1 << attempt)
+		}
+		fmt.Printf(
+			"Request to %s failed with retriable error (attempt %d/%d, status %d): %v. Waiting %v before retrying...\n",
+			req.URL, attempt+1, c.MaxRetries, statusCode, attemptErr, waitDuration,
+		)
+		time.Sleep(waitDuration)
 	}
 
-	return nil, fmt.Errorf("max retries reached for request %s: %w", req.URL, err)
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("no attempt was made for request %s", req.URL)
 }
 
-func isErrorRetriable(statusCode int, retriableStatusCodes []string) bool {
-	var retriable bool = false
-	for _, code := range retriableStatusCodes {
-		if code == fmt.Sprintf("%d", statusCode) {
-			retriable = true
-			break
+// attemptRequest performs a single HTTP attempt and returns the body on success
+// or a fully formatted terminal error on failure. The error message formats
+// here are preserved verbatim from the pre-retry-fix implementation so that
+// callers matching on substrings such as "internal-server-error:",
+// "resource-not-found", "unauthorized:", "forbidden:" or "unexpected status
+// code" continue to behave the same once retries are exhausted.
+//
+// statusCode is 0 when the request failed at the transport layer; the caller
+// in doRequestWithRetry treats those as retriable.
+func (c *Client) attemptRequest(req *http.Request) ([]byte, int, error) {
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer res.Body.Close()
+
+	body, readErr := io.ReadAll(res.Body)
+	statusCode := res.StatusCode
+
+	// Handle 404 errors - check if it's a true not found or a permissions issue
+	if statusCode == 404 {
+		isResourceNotFound, apiErr, parseErr := parseAPIError(body)
+		if parseErr != nil {
+			// If we can't parse the error, return a generic 404
+			return nil, statusCode, fmt.Errorf("resource-not-found (status 404): URL: %s, Response: %s", req.URL, body)
+		}
+
+		if isResourceNotFound {
+			// Check if the error message mentions permissions - this is a common pattern in dbt Cloud API
+			userMsg := strings.ToLower(apiErr.Status.UserMessage)
+			if strings.Contains(userMsg, "permission") || strings.Contains(userMsg, "proper permissions") {
+				return nil, statusCode, fmt.Errorf("resource-not-found-permissions: The resource was not found, but this may be due to insufficient permissions. The API token may not have access to this resource or the environment it belongs to.\n\nStatus: 404\nURL: %s\nMessage: %s", req.URL, apiErr.Status.UserMessage)
+			}
+
+			// For GET requests or DELETE operations, this is typically a legitimate not-found
+			// (DELETE gets 404 when resource already deleted, which is fine)
+			if req.Method == "GET" || req.Method == "DELETE" {
+				return nil, statusCode, fmt.Errorf("resource-not-found: %s", req.URL)
+			}
+
+			// For POST/PUT on non-permission 404s, provide additional context
+			// This helps with update/create operations that fail due to permissions
+			return nil, statusCode, fmt.Errorf("resource-not-found: The resource was not found. If you are updating a resource, this may indicate insufficient permissions.\n\nStatus: 404\nURL: %s\nMessage: %s", req.URL, apiErr.Status.UserMessage)
 		}
 	}
 
-	return retriable
+	if statusCode == 400 {
+		return nil, statusCode, fmt.Errorf("resource-not-found: %s", body)
+	}
+
+	// Handle permission errors (401 Unauthorized, 403 Forbidden)
+	if statusCode == 401 {
+		return nil, statusCode, fmt.Errorf("unauthorized: The API token does not have permission to access this resource. Status: 401, URL: %s, Response: %s", req.URL, body)
+	}
+
+	if statusCode == 403 {
+		return nil, statusCode, fmt.Errorf("forbidden: The API token does not have permission to perform this action. This may be due to environment-level permissions or other access restrictions. Status: 403, URL: %s, Response: %s", req.URL, body)
+	}
+
+	if statusCode == 500 {
+		return nil, statusCode, fmt.Errorf("internal-server-error: %s", body)
+	}
+
+	// Check for other non-2xx status codes
+	if statusCode < 200 || statusCode >= 300 {
+		return nil, statusCode, fmt.Errorf("unexpected status code %d: %s, URL: %s", statusCode, body, req.URL)
+	}
+
+	if readErr != nil {
+		return nil, statusCode, readErr
+	}
+	return body, statusCode, nil
+}
+
+// isHTTPCodeRetriable reports whether statusCode should trigger a retry. The
+// provider-supplied retriableStatusCodes take precedence; if statusCode is not
+// listed there it is also matched against defaultRetriableHTTPCodes so callers
+// that never configured retriable_status_codes still benefit from retry on
+// canonical transient errors.
+func isHTTPCodeRetriable(statusCode int, retriableStatusCodes []string) bool {
+	if statusCode == 0 {
+		return false
+	}
+	for _, code := range retriableStatusCodes {
+		if code == fmt.Sprintf("%d", statusCode) {
+			return true
+		}
+	}
+	for _, code := range defaultRetriableHTTPCodes {
+		if code == statusCode {
+			return true
+		}
+	}
+	return false
+}
+
+// isErrorRetriable is preserved for backwards compatibility with prior call
+// sites. It now defers to isHTTPCodeRetriable so the retry decision is
+// consistent across the client.
+func isErrorRetriable(statusCode int, retriableStatusCodes []string) bool {
+	return isHTTPCodeRetriable(statusCode, retriableStatusCodes)
 }
 
 func isResourceNotFoundError(body []byte) (bool, error) {

--- a/pkg/dbt_cloud/client_retry_test.go
+++ b/pkg/dbt_cloud/client_retry_test.go
@@ -1,0 +1,337 @@
+package dbt_cloud
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// newRetryTestClient builds a Client pointed at the provided httptest.Server
+// with retry timing zeroed out so unit tests do not block on backoff.
+func newRetryTestClient(t *testing.T, serverURL string, maxRetries int, retriable []string) *Client {
+	t.Helper()
+	t.Setenv("TF_ACC", "1") // skip credential validation in NewClient
+
+	accountID := int64(123)
+	token := "test_token"
+	retryInterval := 0
+	timeout := 5
+	skipValidation := true
+
+	c, err := NewClient(
+		&accountID,
+		&token,
+		&serverURL,
+		&maxRetries,
+		&retryInterval,
+		retriable,
+		skipValidation,
+		&timeout,
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+// TestDoRequestWithRetry_RetriesTransient5xxAnd429 verifies that the client
+// retries each canonical transient status, succeeds on the third attempt, and
+// returns the final 2xx body. Without the fix these all returned the first
+// 5xx/429 immediately because the per-status early returns short-circuited the
+// retry block.
+func TestDoRequestWithRetry_RetriesTransient5xxAnd429(t *testing.T) {
+	cases := []int{408, 429, 500, 502, 503, 504}
+	for _, code := range cases {
+		code := code
+		t.Run(fmt.Sprintf("status_%d_retries_then_succeeds", code), func(t *testing.T) {
+			var attempts atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				n := attempts.Add(1)
+				if n <= 2 {
+					http.Error(w, "transient", code)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			defer srv.Close()
+
+			c := newRetryTestClient(t, srv.URL, 3, nil)
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/test/", nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+
+			body, err := c.doRequestWithRetry(req)
+			if err != nil {
+				t.Fatalf("expected success after retries, got: %v", err)
+			}
+			if string(body) != `{"ok":true}` {
+				t.Fatalf("unexpected body: %s", body)
+			}
+			if got := attempts.Load(); got != 3 {
+				t.Fatalf("expected 3 attempts, got %d", got)
+			}
+		})
+	}
+}
+
+// TestDoRequestWithRetry_PreservesTerminalErrorOn500Exhaustion locks in the
+// back-compat contract for callers that match on the "internal-server-error:"
+// prefix. After all retries are exhausted, the surfaced error must still
+// contain that substring so existing diagnostic code paths keep working.
+func TestDoRequestWithRetry_PreservesTerminalErrorOn500Exhaustion(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`<!doctype html><title>Uh oh!</title>`))
+	}))
+	defer srv.Close()
+
+	c := newRetryTestClient(t, srv.URL, 2, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/x/", nil)
+
+	_, err := c.doRequestWithRetry(req)
+	if err == nil {
+		t.Fatal("expected error after retries exhausted")
+	}
+	if !strings.Contains(err.Error(), "internal-server-error:") {
+		t.Fatalf("expected wrapped \"internal-server-error:\" prefix for back-compat, got: %v", err)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("expected 2 attempts, got %d", got)
+	}
+}
+
+// TestDoRequestWithRetry_PreservesTerminalErrorOn502Exhaustion locks in the
+// back-compat contract for the catch-all "unexpected status code" error
+// shape, which is what callers see for 502/503/504/etc when retries are
+// exhausted.
+func TestDoRequestWithRetry_PreservesTerminalErrorOn502Exhaustion(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("<html>502 Bad Gateway</html>"))
+	}))
+	defer srv.Close()
+
+	c := newRetryTestClient(t, srv.URL, 2, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/y/", nil)
+
+	_, err := c.doRequestWithRetry(req)
+	if err == nil {
+		t.Fatal("expected error after retries exhausted")
+	}
+	if !strings.Contains(err.Error(), "unexpected status code 502") {
+		t.Fatalf("expected wrapped \"unexpected status code 502\" prefix, got: %v", err)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("expected 2 attempts, got %d", got)
+	}
+}
+
+// TestDoRequestWithRetry_DoesNotRetry4xx makes sure permission/validation
+// errors still surface immediately without burning the retry budget.
+func TestDoRequestWithRetry_DoesNotRetry4xx(t *testing.T) {
+	cases := []struct {
+		name           string
+		status         int
+		body           string
+		errorSubstring string
+	}{
+		{"401_unauthorized", http.StatusUnauthorized, `{"detail":"bad token"}`, "unauthorized:"},
+		{"403_forbidden", http.StatusForbidden, `{"detail":"nope"}`, "forbidden:"},
+		{"400_bad_request", http.StatusBadRequest, `{"detail":"bad"}`, "resource-not-found:"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var attempts atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempts.Add(1)
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			c := newRetryTestClient(t, srv.URL, 5, nil)
+			req, _ := http.NewRequest(http.MethodGet, srv.URL+"/z/", nil)
+
+			_, err := c.doRequestWithRetry(req)
+			if err == nil {
+				t.Fatal("expected error for 4xx")
+			}
+			if !strings.Contains(err.Error(), tc.errorSubstring) {
+				t.Fatalf("expected error containing %q, got: %v", tc.errorSubstring, err)
+			}
+			if got := attempts.Load(); got != 1 {
+				t.Fatalf("expected exactly 1 attempt for %s, got %d", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestDoRequestWithRetry_HonorsConfiguredRetriableStatusCodes verifies that a
+// status outside the default retriable set still gets retried when the user
+// has explicitly opted in via retriable_status_codes. Picking 418 here so we
+// know the behavior comes from the configured list and not the defaults.
+func TestDoRequestWithRetry_HonorsConfiguredRetriableStatusCodes(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusTeapot) // 418, not in defaultRetriableHTTPCodes
+			_, _ = w.Write([]byte(`steeping`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c := newRetryTestClient(t, srv.URL, 2, []string{"418"})
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/teapot/", nil)
+
+	body, err := c.doRequestWithRetry(req)
+	if err != nil {
+		t.Fatalf("expected retry on configured 418, got: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("expected 2 attempts, got %d", got)
+	}
+}
+
+// TestDoRequestWithRetry_RetriesTransportError ensures that a connection-level
+// failure (server closed before response) is treated as a retriable failure.
+func TestDoRequestWithRetry_RetriesTransportError(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			// Hijack the connection and close it without writing a response.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("server does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("Hijack: %v", err)
+			}
+			_ = conn.Close()
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c := newRetryTestClient(t, srv.URL, 3, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/transport/", nil)
+
+	body, err := c.doRequestWithRetry(req)
+	if err != nil {
+		t.Fatalf("expected success after transport-error retry, got: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := attempts.Load(); got < 2 {
+		t.Fatalf("expected at least 2 attempts after transport failure, got %d", got)
+	}
+}
+
+// TestDoRequestWithRetry_DisableRetryStillReturnsSuccess sanity-checks that
+// disabling retry produces exactly one attempt and returns the body
+// unchanged.
+func TestDoRequestWithRetry_DisableRetryStillReturnsSuccess(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c := newRetryTestClient(t, srv.URL, 3, nil)
+	c.DisableRetry = true
+	c.MaxRetries = 0 // force the floor-at-1 branch in doRequestWithRetry
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/ok/", nil)
+	body, err := c.doRequestWithRetry(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 attempt with retry disabled, got %d", got)
+	}
+}
+
+// TestIsHTTPCodeRetriable covers the helper directly since it now influences
+// every API call from the provider.
+func TestIsHTTPCodeRetriable(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		configured []string
+		want       bool
+	}{
+		{"transport-error-status-zero", 0, nil, false},
+		{"default-500", 500, nil, true},
+		{"default-502", 502, nil, true},
+		{"default-503", 503, nil, true},
+		{"default-504", 504, nil, true},
+		{"default-408", 408, nil, true},
+		{"default-429", 429, nil, true},
+		{"default-501-not-retriable", 501, nil, false},
+		{"default-200-not-retriable", 200, nil, false},
+		{"default-404-not-retriable", 404, nil, false},
+		{"configured-extra-418", 418, []string{"418"}, true},
+		{"configured-empty-still-uses-defaults", 502, []string{}, true},
+		{"configured-list-without-defaults-still-includes-defaults", 500, []string{"418"}, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := isHTTPCodeRetriable(tc.statusCode, tc.configured)
+			if got != tc.want {
+				t.Errorf("isHTTPCodeRetriable(%d, %v) = %v, want %v",
+					tc.statusCode, tc.configured, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsErrorRetriable_BackwardsCompatible ensures the legacy helper still
+// returns the same answers as the new isHTTPCodeRetriable so any external
+// callers that linked against it continue to work.
+func TestIsErrorRetriable_BackwardsCompatible(t *testing.T) {
+	cases := []struct {
+		statusCode int
+		configured []string
+	}{
+		{500, nil},
+		{502, nil},
+		{418, []string{"418"}},
+		{200, nil},
+		{404, nil},
+	}
+	for _, tc := range cases {
+		got := isErrorRetriable(tc.statusCode, tc.configured)
+		want := isHTTPCodeRetriable(tc.statusCode, tc.configured)
+		if got != want {
+			t.Errorf("isErrorRetriable(%d, %v) = %v, isHTTPCodeRetriable = %v",
+				tc.statusCode, tc.configured, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Resolves #695.

## Summary

`pkg/dbt_cloud/client.go::doRequestWithRetry` advertises retry-with-exponential-backoff via `MaxRetries`, `RetryIntervalSeconds`, and `RetriableStatusCodes` (provider config: `max_retries`, `retry_interval_seconds`, `retriable_status_codes`, defaulting to `[\"429\",\"500\",\"502\",\"503\",\"504\"]`). In practice the retry branch was unreachable: per-status `if res.StatusCode == … { return … }` blocks short-circuited every non-2xx response before the retry decision ran. Transient 5xx/429 responses from `cloud.getdbt.com` therefore surfaced as one-shot Terraform diagnostics on the very first attempt.

This change reorganizes the loop so any retriable status (defaults: `408, 429, 500, 502, 503, 504`, plus user-configured `retriable_status_codes`) and any transport-level failure now routes through the existing exponential-backoff path. After retries are exhausted, the surfaced error string is unchanged for back-compat with callers matching on \"internal-server-error:\", \"resource-not-found\", \"unauthorized:\", \"forbidden:\", and \"unexpected status code\" prefixes.

## Tracing the bug

Two recent post-merge / scheduled `unit (test-acceptance)` failures on `main`, no shared test, no shared package — only a shared symptom: a transient 5xx surfaced verbatim from the dbt Cloud API.

**2026-05-26**, run [26459657437](https://github.com/dbt-labs/terraform-provider-dbtcloud/actions/runs/26459657437), `TestAccDbtCloudPartialNotificationResource`:
\`\`\`
Error: Error Reading dbt Cloud Project
  ...
  Could not read project ID 543791: unexpected status code 502: <html>
  <head><title>502 Bad Gateway</title></head>
  ...
  , URL:
  https://cloud.getdbt.com/api/v3/accounts/***/projects/543791/?include_related=[freshness_job_id,docs_job_id]
\`\`\`

**2026-04-26** (scheduled), run [24947744549](https://github.com/dbt-labs/terraform-provider-dbtcloud/actions/runs/24947744549), `TestAccDbtCloudOpenAIIntegrationResource_OpenAI` and `_KeyValue`:
\`\`\`
Error: Unable to create OpenAI integration
  ...
  internal-server-error: <!doctype html>
  <html lang="en">
    ...
    <title>Uh oh! | dbt</title>
\`\`\`

The next merges to `main` after each were green with no test changes — confirming environmental flakes, not test bugs.

### Root cause

The previous `doRequestWithRetry` loop body looked like this (simplified):

\`\`\`go
for i := 0; i < c.MaxRetries; i++ {
    res, err := c.HTTPClient.Do(req)
    if err != nil { return nil, err }                      // (a) transport error → no retry
    defer res.Body.Close()                                 // (b) deferred inside loop
    body, err := io.ReadAll(res.Body)

    if res.StatusCode == 404 { … return … }                // (c) per-status early returns
    if res.StatusCode == 400 { return … }
    if res.StatusCode == 401 { return … }
    if res.StatusCode == 403 { return … }
    if res.StatusCode == 500 {
        return nil, fmt.Errorf(\"internal-server-error: %s\", body)
    }
    if res.StatusCode < 200 || res.StatusCode >= 300 {
        return nil, fmt.Errorf(\"unexpected status code %d: %s, URL: %s\", res.StatusCode, body, req.URL)
    }

    if err == nil {
        return body, nil
    } else {
        if isErrorRetriable(res.StatusCode, c.RetriableStatusCodes) {  // (d) unreachable
            // backoff + continue
        }
    }
    return nil, err
}
\`\`\`

Mapping the May 26 failure (502):
- `res.StatusCode == 500` is false → fall through.
- `res.StatusCode < 200 || res.StatusCode >= 300` is true → returns `unexpected status code 502: …` with no retry.

Mapping the April 26 failure (500):
- `res.StatusCode == 500` is true → returns `internal-server-error: …` with no retry.

In both cases the retry block (d) is unreachable because the per-status early returns (c) bail out first. (d) is only reached when `err != nil` from `io.ReadAll` AND status is 2xx — essentially never.

Secondary issues fixed alongside:
- `defer res.Body.Close()` inside the loop accumulates deferred closes across iterations instead of closing per-iteration.
- `res, err := c.HTTPClient.Do(req)` shadows the outer `err`, so the function's exhausted-retries `return nil, fmt.Errorf(\"max retries reached for request %s: %w\", req.URL, err)` always wraps a `nil`-or-stale `err`.
- Transport-level failures (DNS, connection reset, dial timeout) were not retried.

## Fix

`doRequestWithRetry` now decides retriability *before* mapping the status into a terminal error. The mapping itself moves into a small helper, `attemptRequest`, which preserves every existing error-message format. This is the minimal change that makes the documented behavior (retriable_status_codes defaulting to `[429, 500, 502, 503, 504]`) actually work.

Key behavior changes:
- `408, 429, 500, 502, 503, 504` retry by default; **501 stays terminal** (intentionally — Not Implemented is a permanent missing feature, not a transient failure).
- User-configured `retriable_status_codes` continue to take precedence; the default list is additive, not overriding.
- Transport-level errors retry once per attempt as well.
- After retries exhaust, the error string is byte-identical to today's terminal error (locked in by tests).
- 4xx terminal codes (400/401/403/404) still surface immediately on the first attempt — no wasted retry budget on permission/validation errors.
- `isErrorRetriable` is preserved as a thin wrapper that defers to the new `isHTTPCodeRetriable`, so any external caller (none in this repo, but harmless) still works.

## Test plan

- [x] `go build ./pkg/dbt_cloud/...`
- [x] `go vet ./pkg/dbt_cloud/...`
- [x] `go test -count=1 ./pkg/dbt_cloud/...` (existing + new)
- [x] `go test -count=1 ./...` — full unit suite (no `TF_ACC`) green
- [x] `TestDoRequestWithRetry_RetriesTransient5xxAnd429` covers `408, 429, 500, 502, 503, 504` retry-then-success
- [x] `TestDoRequestWithRetry_PreservesTerminalErrorOn500Exhaustion` locks `internal-server-error:` substring
- [x] `TestDoRequestWithRetry_PreservesTerminalErrorOn502Exhaustion` locks `unexpected status code 502` substring
- [x] `TestDoRequestWithRetry_DoesNotRetry4xx` (401 / 403 / 400) — exactly one attempt
- [x] `TestDoRequestWithRetry_HonorsConfiguredRetriableStatusCodes` (418 via configured list)
- [x] `TestDoRequestWithRetry_RetriesTransportError` (hijacked-and-closed connection)
- [x] `TestDoRequestWithRetry_DisableRetryStillReturnsSuccess`
- [x] `TestIsHTTPCodeRetriable` table tests
- [x] `TestIsErrorRetriable_BackwardsCompatible` (legacy helper still works)
- [ ] CI `unit (test-acceptance)` — passes against the live dbt Cloud API.

Made with [Cursor](https://cursor.com)