### PR TITLE
Fix update for BQ global connection

### DIFF
--- a/.changes/unreleased/Fixes-20260528-093810.yaml
+++ b/.changes/unreleased/Fixes-20260528-093810.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fix update for BQ global connection
+time: 2026-05-28T09:38:10.215562+03:00

--- a/pkg/dbt_cloud/global_connection.go
+++ b/pkg/dbt_cloud/global_connection.go
@@ -202,26 +202,6 @@ func (c *GlobalConnectionClient[T]) createGlobalConnection(
 	return &resp.Data, nil
 }
 
-func (c *GlobalConnectionClient[T]) UpdateWithLatestAdapter(
-	connectionID int64,
-	common GlobalConnectionCommon,
-	config T,
-	av string,
-) (*GlobalConnectionCommon, *T, error) {
-
-	buffer := new(bytes.Buffer)
-	enc := json.NewEncoder(buffer)
-
-	payload := globalConnectionPayload[T]{
-		GlobalConnectionCommon: common,
-		AccountID:              int64(c.AccountID),
-		AdapterVersion:         &av,
-		Config:                 config,
-	}
-
-	return updateGlobalConnection(enc, payload, c, connectionID, buffer)
-}
-
 func (c *GlobalConnectionClient[T]) Update(
 	connectionID int64,
 	common GlobalConnectionCommon,

--- a/pkg/framework/objects/global_connection/resource.go
+++ b/pkg/framework/objects/global_connection/resource.go
@@ -94,6 +94,25 @@ func (r globalConnectionResource) ModifyPlan(
 		}
 	}
 
+	// dbt Cloud does not allow changing the adapter version of an existing connection
+	// (the PATCH endpoint rejects `adapter_version`). Surface this at plan time with a
+	// clear, actionable message so the user sees it before `terraform apply` starts
+	// mutating other attributes. The Update path retains a defensive runtime check.
+	if plan.BigQueryConfig != nil && state.BigQueryConfig != nil &&
+		plan.BigQueryConfig.UseLatestAdapter.ValueBool() != state.BigQueryConfig.UseLatestAdapter.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("bigquery").AtName("use_latest_adapter"),
+			"Adapter version cannot be changed on an existing connection",
+			"dbt Cloud does not support changing the BigQuery adapter version "+
+				"(`use_latest_adapter`) on an existing global connection. To switch between "+
+				"the legacy (bigquery_v0) and latest (bigquery_v1) adapter, recreate the "+
+				"connection — for example, run `terraform apply -replace=<resource address>` "+
+				"(see https://developer.hashicorp.com/terraform/cli/commands/plan#replace-address). "+
+				"Note that recreating the connection will issue a new connection ID, so any "+
+				"resources referencing it will also be updated.",
+		)
+	}
+
 }
 
 func (r *globalConnectionResource) Read(
@@ -1014,34 +1033,27 @@ func (r *globalConnectionResource) Update(
 			}
 		}
 
-		var updateCommon *dbt_cloud.GlobalConnectionCommon
-		var err error
+		// The dbt Cloud PATCH endpoint does not accept `adapter_version` — the field
+		// is absent from `AccountConnectionUpdateBody` and a backend regression test
+		// (sinter `test_account_connections.py::test__patch__cannot_set_adapter_version`)
+		// guarantees `400: adapter_version: extra fields not permitted`. The resource
+		// layer also blocks adapter version changes upstream (ModifyPlan + the runtime
+		// check below), so v0 and v1 share the same PATCH call here.
+		updateCommon, _, err := c.Update(
+			state.ID.ValueInt64(),
+			globalConfigChanges,
+			warehouseConfigChanges,
+		)
+		if err != nil {
+			resp.Diagnostics.AddError("Error updating global connection", err.Error())
+			return
+		}
 
-		// at this point we have updated the adapter version in the plan, so use it
 		var adapterVersion string
-		if !plan.BigQueryConfig.UseLatestAdapter.ValueBool() {
-			updateCommon, _, err = c.Update(
-				state.ID.ValueInt64(),
-				globalConfigChanges,
-				warehouseConfigChanges,
-			)
-			if err != nil {
-				resp.Diagnostics.AddError("Error updating global connection", err.Error())
-				return
-			}
-			adapterVersion = warehouseConfigChanges.AdapterVersion()
-		} else {
-			updateCommon, _, err = c.UpdateWithLatestAdapter(
-				state.ID.ValueInt64(),
-				globalConfigChanges,
-				warehouseConfigChanges,
-				warehouseConfigChanges.LatestAdapterVersion(),
-			)
-			if err != nil {
-				resp.Diagnostics.AddError("Error updating global connection", err.Error())
-				return
-			}
+		if plan.BigQueryConfig.UseLatestAdapter.ValueBool() {
 			adapterVersion = warehouseConfigChanges.LatestAdapterVersion()
+		} else {
+			adapterVersion = warehouseConfigChanges.AdapterVersion()
 		}
 
 		// we set the computed values, no need to do it for ID as we use a PlanModifier with UseStateForUnknown()

--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -525,14 +525,15 @@ func TestAccDbtCloudGlobalConnectionBigQueryUpdateV1AdapterFromV0(t *testing.T) 
 					),
 				),
 			},
-			// modify, adding optional fields
+			// modify, adding optional fields — flipping use_latest_adapter must be
+			// rejected. The ModifyPlan guard now fails the plan with a friendlier
+			// message; the runtime check at the Update path remains as a fallback.
 			{
 				Config: testAccDbtCloudSGlobalConnectionBigQueryResourceBasicConfigWithJobExecutionTimeoutSeconds(
 					connectionName,
 					jobExecutionTimeoutSeconds,
 				),
-				// expect an error
-				ExpectError: regexp.MustCompile("Changing the adapter version is not supported."),
+				ExpectError: regexp.MustCompile("Adapter version cannot be changed"),
 			},
 
 			// IMPORT

--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -2031,3 +2031,142 @@ resource "dbtcloud_global_connection" test {
 
 `, connectionName, loginURL, database, dataTransformRunTimeout)
 }
+
+// TestAccDbtCloudGlobalConnectionBigQueryV1UpdateIssue685 covers GitHub issue #685.
+//
+// Background: the dbt Cloud PATCH endpoint for connections does NOT accept the
+// `adapter_version` field — the backend's `AccountConnectionUpdateBody` schema
+// omits it, and a backend regression test asserts a 400 with
+// "adapter_version: extra fields not permitted" if the field is sent. The
+// adapter version is therefore set at creation and immutable thereafter.
+//
+// Pre-fix behavior: when a BigQuery connection was created with
+// `use_latest_adapter = true`, every update — even one that only changed `name`
+// or `timeout_seconds` — went through `UpdateWithLatestAdapter`, which stuffed
+// `adapter_version` into the PATCH body. The API rejected it, so v1 BigQuery
+// connections were effectively immutable.
+//
+// Post-fix behavior: v0 and v1 BigQuery updates share the same PATCH call that
+// every other connection type uses (no `adapter_version` in the body), and any
+// attempt to actually change `use_latest_adapter` is rejected at plan time with
+// a clear, actionable message.
+func TestAccDbtCloudGlobalConnectionBigQueryV1UpdateIssue685(t *testing.T) {
+	connectionName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	connectionName2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	jobExecutionTimeoutSeconds := int64(1000)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create a BigQuery v1 connection.
+			{
+				Config: testAccDbtCloudSGlobalConnectionBigQueryResourceBasicConfigWithJobExecutionTimeoutSeconds(
+					connectionName,
+					jobExecutionTimeoutSeconds,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"dbtcloud_global_connection.test",
+						"id",
+					),
+					resource.TestCheckResourceAttr(
+						"dbtcloud_global_connection.test",
+						"adapter_version",
+						"bigquery_v1",
+					),
+					resource.TestCheckResourceAttr(
+						"dbtcloud_global_connection.test",
+						"bigquery.use_latest_adapter",
+						"true",
+					),
+				),
+			},
+			// Step 2: rename the connection — the exact scenario from #685.
+			// Before the fix this failed with
+			// "adapter_version: extra fields not permitted".
+			{
+				Config: testAccDbtCloudSGlobalConnectionBigQueryResourceBasicConfigWithJobExecutionTimeoutSeconds(
+					connectionName2,
+					jobExecutionTimeoutSeconds,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"dbtcloud_global_connection.test",
+						"name",
+						connectionName2,
+					),
+					resource.TestCheckResourceAttr(
+						"dbtcloud_global_connection.test",
+						"adapter_version",
+						"bigquery_v1",
+					),
+				),
+			},
+			// Step 3: change a v1-only attribute (job_execution_timeout_seconds) to
+			// exercise the PATCH path a second time.
+			{
+				Config: testAccDbtCloudSGlobalConnectionBigQueryResourceBasicConfigWithJobExecutionTimeoutSeconds(
+					connectionName2,
+					jobExecutionTimeoutSeconds+500,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"dbtcloud_global_connection.test",
+						"bigquery.job_execution_timeout_seconds",
+						fmt.Sprintf("%d", jobExecutionTimeoutSeconds+500),
+					),
+					resource.TestCheckResourceAttr(
+						"dbtcloud_global_connection.test",
+						"adapter_version",
+						"bigquery_v1",
+					),
+				),
+			},
+			// Step 4: intentionally flip use_latest_adapter — this must fail at
+			// plan time with the friendly ModifyPlan error, not mid-apply with a
+			// raw API error.
+			{
+				Config: testAccDbtCloudGlobalConnectionBigQueryV1FlipAdapterConfig(
+					connectionName2,
+					jobExecutionTimeoutSeconds,
+				),
+				ExpectError: regexp.MustCompile("Adapter version cannot be changed"),
+			},
+		},
+	})
+}
+
+// testAccDbtCloudGlobalConnectionBigQueryV1FlipAdapterConfig is the same shape as
+// the v1 create config, but with use_latest_adapter explicitly set to false to
+// exercise the ModifyPlan guard against changing the adapter version on an
+// existing connection.
+func testAccDbtCloudGlobalConnectionBigQueryV1FlipAdapterConfig(
+	connectionName string,
+	jobExecutionTimeoutSeconds int64,
+) string {
+	return fmt.Sprintf(`
+
+resource dbtcloud_global_connection test {
+  name = "%s"
+
+  bigquery = {
+
+    gcp_project_id              = "70403103977025"
+    private_key_id              = "my-private-key-id"
+    private_key                 = "ABCDEFGHIJKL"
+    client_email                = "my_client_email"
+    client_id                   = "my_client_id"
+    auth_uri                    = "my_auth_uri"
+    token_uri                   = "my_token_uri"
+    auth_provider_x509_cert_url = "my_auth_provider_x509_cert_url"
+    client_x509_cert_url        = "my_client_x509_cert_url"
+    application_id              = "oauth_application_id"
+    application_secret          = "oauth_secret_id"
+    job_execution_timeout_seconds = %d
+    use_latest_adapter = false
+  }
+}
+
+`, connectionName, jobExecutionTimeoutSeconds)
+}


### PR DESCRIPTION
## Summary

Fixes #685: BigQuery v1 global connections (`use_latest_adapter = true`) were effectively immutable. The provider sent `adapter_version` in every PATCH, and the dbt Cloud API rejects that field (`adapter_version: extra fields not permitted`), so renaming a v1 connection — or changing any other mutable attribute — failed.

The dbt Cloud API contract is that adapter version is set at create and immutable thereafter (`AccountConnectionUpdateBody` schema in `sinter/api/v3/account_connections/account_connections_schemas.py` has no `adapter_version` field, and there's a backend regression test asserting the 400). So the right fix is provider-side: stop sending the field on PATCH, and warn users earlier if they try to change it.

## Changes

- **`pkg/dbt_cloud/global_connection.go`** — removed `UpdateWithLatestAdapter`. Once `adapter_version` is dropped from the payload it's identical to `Update`.
- **`pkg/framework/objects/global_connection/resource.go`** — v0 and v1 BigQuery updates now share the same PATCH call. Added a `ModifyPlan` check that rejects `use_latest_adapter` changes at plan time with an actionable message pointing at `terraform apply -replace=<address>`. The existing runtime check at line 897 stays as defense in depth.
- **`pkg/framework/objects/global_connection/resource_acceptance_test.go`** — new `TestAccDbtCloudGlobalConnectionBigQueryV1UpdateIssue685` covering: create v1, rename (the reporter's scenario), change another v1 attribute, and the plan-time guard against flipping `use_latest_adapter`.
- **`test-scenarios/issue-685-bigquery-v1-update/`** — manual repro workspace with a README.
- Two changelog entries under `.changes/unreleased/`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `TF_ACC=1 go test -run TestAccDbtCloudGlobalConnectionBigQueryV1UpdateIssue685 -timeout 30m ./pkg/framework/objects/global_connection/...`
- [x] Manual repro per `test-scenarios/issue-685-bigquery-v1-update/README.md`
- [ ] (Optional) Revert `pkg/dbt_cloud/global_connection.go` and re-run the acceptance test — step 2 should fail with `adapter_version: extra fields not permitted`, confirming the test catches the regression