### PR TITLE
Fix schema validation for sl creds

### DIFF
--- a/.changes/unreleased/Fixes-20260622-165954.yaml
+++ b/.changes/unreleased/Fixes-20260622-165954.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fix handling of wo attributes and sl credentials
+time: 2026-06-22T16:59:54.291212+03:00

--- a/pkg/framework/objects/databricks_credential/schema.go
+++ b/pkg/framework/objects/databricks_credential/schema.go
@@ -88,8 +88,8 @@ var DatabricksResourceSchema = resource_schema.Schema{
 			Optional:    true,
 			Sensitive:   true,
 			Validators: []validator.String{
-				stringvalidator.ConflictsWith(path.MatchRoot("token_wo")),
-				stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("token_wo")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("token_wo")),
+				helper.PreferWriteOnlyAttributeValidator{WriteOnlyAttributeName: "token_wo"},
 			},
 		},
 		"token_wo": resource_schema.StringAttribute{
@@ -97,7 +97,7 @@ var DatabricksResourceSchema = resource_schema.Schema{
 			WriteOnly:   true,
 			Description: "Write-only alternative to `token`. The value is not stored in state. Requires `token_wo_version` to trigger updates.",
 			Validators: []validator.String{
-				stringvalidator.ConflictsWith(path.MatchRoot("token")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("token")),
 			},
 		},
 		"token_wo_version": resource_schema.Int64Attribute{
@@ -121,11 +121,11 @@ var DatabricksResourceSchema = resource_schema.Schema{
 			},
 		},
 		"adapter_type": resource_schema.StringAttribute{
-			Description: "The type of the adapter. 'spark' is deprecated, but still supported for backwards compatibility. For Spark, please use the spark_credential resource. Optional only when semantic_layer_credential is set to true; otherwise, this field is required.",
-			Optional:    true,
-			Computed:    true,
+			Description:        "The type of the adapter. 'spark' is deprecated, but still supported for backwards compatibility. For Spark, please use the spark_credential resource. Optional only when semantic_layer_credential is set to true; otherwise, this field is required.",
+			Optional:           true,
+			Computed:           true,
 			DeprecationMessage: "This field is deprecated and will be removed in a future release. Semantic Layer spark credentials are not supported yet, only databricks is supported.",
-			Default:     stringdefault.StaticString("databricks"),
+			Default:            stringdefault.StaticString("databricks"),
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},

--- a/pkg/framework/objects/postgres_credential/schema.go
+++ b/pkg/framework/objects/postgres_credential/schema.go
@@ -112,8 +112,8 @@ var PostgresResourceSchema = resource_schema.Schema{
 			Sensitive:   true,
 			Description: "Password for Postgres/Redshift/AlloyDB. Consider using `password_wo` instead, which is not stored in state.",
 			Validators: []validator.String{
-				stringvalidator.ConflictsWith(path.MatchRoot("password_wo")),
-				stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("password_wo")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("password_wo")),
+				helper.PreferWriteOnlyAttributeValidator{WriteOnlyAttributeName: "password_wo"},
 			},
 		},
 		"password_wo": resource_schema.StringAttribute{
@@ -121,7 +121,7 @@ var PostgresResourceSchema = resource_schema.Schema{
 			WriteOnly:   true,
 			Description: "Write-only alternative to `password`. The value is not stored in state. Requires `password_wo_version` to trigger updates.",
 			Validators: []validator.String{
-				stringvalidator.ConflictsWith(path.MatchRoot("password")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("password")),
 			},
 		},
 		"password_wo_version": resource_schema.Int64Attribute{

--- a/pkg/framework/objects/redshift_credential/schema.go
+++ b/pkg/framework/objects/redshift_credential/schema.go
@@ -58,8 +58,8 @@ var RedshiftResourceSchema = resource_schema.Schema{
 			Computed:    true,
 			Default:     stringdefault.StaticString(""),
 			Validators: []validator.String{
-				stringvalidator.ConflictsWith(path.MatchRoot("password_wo")),
-				stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("password_wo")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("password_wo")),
+				helper.PreferWriteOnlyAttributeValidator{WriteOnlyAttributeName: "password_wo"},
 			},
 		},
 		"password_wo": resource_schema.StringAttribute{
@@ -67,7 +67,7 @@ var RedshiftResourceSchema = resource_schema.Schema{
 			WriteOnly:   true,
 			Description: "Write-only alternative to `password`. The value is not stored in state. Requires `password_wo_version` to trigger updates.",
 			Validators: []validator.String{
-				stringvalidator.ConflictsWith(path.MatchRoot("password")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("password")),
 			},
 		},
 		"password_wo_version": resource_schema.Int64Attribute{

--- a/pkg/framework/objects/semantic_layer_credential/snowflake_sl_credential_unit_test.go
+++ b/pkg/framework/objects/semantic_layer_credential/snowflake_sl_credential_unit_test.go
@@ -1,0 +1,117 @@
+package semantic_layer_credential_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/testhelpers"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestSnowflakeSLCredential_NestedSchemaValidatesPlan is an offline regression
+// test for the "Invalid Path Expression for Schema" bug.
+//
+// The Snowflake (and Redshift/Postgres/Databricks) Semantic Layer credential
+// resources reuse the stand-alone credential schema verbatim under a nested
+// `credential` attribute. The reused schema declared its write-only conflict
+// validators with absolute paths (path.MatchRoot("private_key_wo"), etc). When
+// nested, those paths resolve against the Semantic Layer resource root — where
+// `private_key_wo` does not exist (it lives at `credential.private_key_wo`) — so
+// ValidateResourceConfig rejected every plan with an "Invalid Path Expression for
+// Schema" error before any API call was made.
+//
+// These steps only run validate + plan (PlanOnly), which is exactly where the
+// bug fired, so no create/read API mocks are required.
+//
+// Note on what gets set: the broken validators are attached to the *plaintext*
+// attributes (password / private_key / private_key_passphrase) and merely point
+// at their write-only sibling (password_wo, ...) as the conflict target. The
+// ConflictsWith validator short-circuits when the attribute it is attached to is
+// null, so it only resolves the (previously invalid) sibling path when the
+// plaintext attribute has a value. We therefore set the plaintext secrets — not
+// the *_wo attributes — to force those validators to execute against the nested
+// schema and reproduce the original "Invalid Path Expression for Schema" error.
+func TestSnowflakeSLCredential_NestedSchemaValidatesPlan(t *testing.T) {
+	originalTFAcc := os.Getenv("TF_ACC")
+	os.Setenv("TF_ACC", "1")
+	defer func() {
+		if originalTFAcc == "" {
+			os.Unsetenv("TF_ACC")
+		} else {
+			os.Setenv("TF_ACC", originalTFAcc)
+		}
+	}()
+
+	// A mock server is only needed so the provider has a valid host_url; PlanOnly
+	// steps never reach create/read, so no handlers are registered.
+	srv := testhelpers.SetupMockServer(t, map[string]testhelpers.MockEndpointHandler{})
+	defer srv.Close()
+
+	providerConfig := fmt.Sprintf(`
+		provider "dbtcloud" {
+			host_url   = "%s"
+			token      = "dummy-token"
+			account_id = 1
+		}`, srv.URL)
+
+	passwordAuthConfig := providerConfig + `
+		resource "dbtcloud_snowflake_semantic_layer_credential" "test" {
+		  configuration = {
+		    project_id      = 123
+		    name            = "test-sl-credential"
+		    adapter_version = "snowflake_v0"
+		  }
+		  credential = {
+		    project_id                = 123
+		    is_active                 = true
+		    auth_type                 = "password"
+		    role                      = "test_role"
+		    warehouse                 = "test_warehouse"
+		    user                      = "test_user"
+		    password                  = "test_password"
+		    num_threads               = 3
+		    semantic_layer_credential = true
+		  }
+		}`
+
+	keypairAuthConfig := providerConfig + `
+		resource "dbtcloud_snowflake_semantic_layer_credential" "test" {
+		  configuration = {
+		    project_id      = 123
+		    name            = "test-sl-credential"
+		    adapter_version = "snowflake_v0"
+		  }
+		  credential = {
+		    project_id                = 123
+		    is_active                 = true
+		    auth_type                 = "keypair"
+		    role                      = "test_role"
+		    warehouse                 = "test_warehouse"
+		    private_key               = "test_private_key"
+		    private_key_passphrase    = "test_passphrase"
+		    num_threads               = 3
+		    semantic_layer_credential = true
+		  }
+		}`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Exercises the password / password_wo conflict validators.
+				Config:             passwordAuthConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// Exercises the private_key(_passphrase) / *_wo conflict validators.
+				Config:             keypairAuthConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}

--- a/pkg/framework/objects/snowflake_credential/schema.go
+++ b/pkg/framework/objects/snowflake_credential/schema.go
@@ -125,8 +125,8 @@ var SnowflakeCredentialResourceSchema = resource_schema.Schema{
 			Default:     stringdefault.StaticString(""),
 			Validators: []validator.String{
 				snowflake_credential.ConflictValidator{ConflictingFields: []string{"private_key", "private_key_passphrase"}},
-				stringvalidator.ConflictsWith(path.MatchRoot("password_wo")),
-				stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("password_wo")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("password_wo")),
+				helper.PreferWriteOnlyAttributeValidator{WriteOnlyAttributeName: "password_wo"},
 			},
 		},
 		"password_wo": resource_schema.StringAttribute{
@@ -149,8 +149,8 @@ var SnowflakeCredentialResourceSchema = resource_schema.Schema{
 			Description: "The private key for the Snowflake account. Consider using `private_key_wo` instead, which is not stored in state.",
 			Validators: []validator.String{
 				snowflake_credential.ConflictValidator{ConflictingFields: []string{"password"}},
-				stringvalidator.ConflictsWith(path.MatchRoot("private_key_wo")),
-				stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("private_key_wo")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("private_key_wo")),
+				helper.PreferWriteOnlyAttributeValidator{WriteOnlyAttributeName: "private_key_wo"},
 			},
 		},
 		"private_key_wo": resource_schema.StringAttribute{
@@ -173,8 +173,8 @@ var SnowflakeCredentialResourceSchema = resource_schema.Schema{
 			Description: "The passphrase for the private key. Consider using `private_key_passphrase_wo` instead, which is not stored in state.",
 			Validators: []validator.String{
 				snowflake_credential.ConflictValidator{ConflictingFields: []string{"password"}},
-				stringvalidator.ConflictsWith(path.MatchRoot("private_key_passphrase_wo")),
-				stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("private_key_passphrase_wo")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("private_key_passphrase_wo")),
+				helper.PreferWriteOnlyAttributeValidator{WriteOnlyAttributeName: "private_key_passphrase_wo"},
 			},
 		},
 		"private_key_passphrase_wo": resource_schema.StringAttribute{

--- a/pkg/helper/prefer_write_only_validator.go
+++ b/pkg/helper/prefer_write_only_validator.go
@@ -1,0 +1,64 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// PreferWriteOnlyAttributeValidator emits a warning recommending the write-only
+// alternative when a non-write-only attribute has a value set.
+//
+// It exists because stringvalidator.PreferWriteOnlyAttribute (from
+// terraform-plugin-framework-validators) takes an absolute path.Expression and
+// evaluates it against the resource root without merging it with the path of the
+// attribute being validated. That works for a stand-alone resource, but breaks
+// when the same schema is reused inside a nested attribute (for example, the
+// credential schemas reused under `credential` for the Semantic Layer
+// resources), where the write-only sibling no longer lives at the resource root.
+//
+// This validator resolves the write-only sibling relative to the attribute being
+// validated via req.Path.ParentPath().AtName(...), mirroring the approach already
+// used by the conflict validators, so it works whether the schema is used at the
+// resource root or nested inside another attribute.
+type PreferWriteOnlyAttributeValidator struct {
+	// WriteOnlyAttributeName is the name of the sibling write-only attribute that
+	// should be preferred over the attribute this validator is applied to.
+	WriteOnlyAttributeName string
+}
+
+func (v PreferWriteOnlyAttributeValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v PreferWriteOnlyAttributeValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf(
+		"The write-only attribute `%s` should be preferred over this attribute",
+		v.WriteOnlyAttributeName,
+	)
+}
+
+func (v PreferWriteOnlyAttributeValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	// Only emit the warning when the Terraform client supports write-only attributes.
+	if !req.ClientCapabilities.WriteOnlyAttributesAllowed {
+		return
+	}
+
+	// No warning is needed when this attribute has no usable value set.
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	writeOnlyPath := req.Path.ParentPath().AtName(v.WriteOnlyAttributeName)
+
+	resp.Diagnostics.AddAttributeWarning(
+		req.Path,
+		"Available Write-Only Attribute Alternative",
+		fmt.Sprintf(
+			"This attribute has a WriteOnly version %s available. "+
+				"Use the WriteOnly version of the attribute when possible.",
+			writeOnlyPath.String(),
+		),
+	)
+}


### PR DESCRIPTION

## Changes

### Bug fix — relative path expressions
All `ConflictsWith` validators in the Snowflake, Databricks, Postgres, and Redshift credential schemas now use `path.MatchRelative().AtParent().AtName(...)` instead of `path.MatchRoot(...)`. Relative paths work correctly whether the schema is used at the resource root or nested inside another attribute.

### New helper validator
`pkg/helper/prefer_write_only_validator.go` introduces `PreferWriteOnlyAttributeValidator` to replace `stringvalidator.PreferWriteOnlyAttribute(...)` from the framework-validators library. The built-in validator takes an absolute path expression (same root issue); this replacement resolves the write-only sibling via `req.Path.ParentPath().AtName(...)`.

### Regression test
`TestSnowflakeSLCredential_NestedSchemaValidatesPlan` is an offline unit test that runs `PlanOnly` steps for both password and keypair auth configs against a mock server — no live credentials required. It reproduces the original failure and guards against regressions.

## Testing

- [x] Existing credential acceptance tests pass
- [x] New unit test `TestSnowflakeSLCredential_NestedSchemaValidatesPlan` passes
- [x] `dbtcloud_snowflake_semantic_layer_credential` plan no longer errors with `Invalid Path Expression for Schema`
