### PR TITLE
Add documentation and validation for Slack V2

### DIFF
--- a/.changes/unreleased/Documentation-20260629-101839.yaml
+++ b/.changes/unreleased/Documentation-20260629-101839.yaml
@@ -1,0 +1,3 @@
+kind: Documentation
+body: Document usage for Slack V2 notifications
+time: 2026-06-29T10:18:39.061612+03:00

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -44,7 +44,7 @@ resource "dbtcloud_notification" "prod_job_external_notification" {
   external_email = "my_email@mail.com"
 }
 
-// and finally, we can set up Slack notifications
+// we can set up Slack notifications using the legacy, per-user Slack integration
 resource "dbtcloud_notification" "prod_job_slack_notifications" {
   // we need the ID of the user that set up the Slack Integration to properly send notifications
   user_id    = 200
@@ -52,6 +52,18 @@ resource "dbtcloud_notification" "prod_job_slack_notifications" {
   on_cancel  = [dbtcloud_job.prod_job.id]
   // the Type 2 is used for Slack notifications
   notification_type  = 2
+  slack_channel_id   = "C12345ABCDE"
+  slack_channel_name = "#my-awesome-channel"
+}
+
+// or we can use the account-level Slack (V2) integration set up via OAuth
+resource "dbtcloud_notification" "prod_job_slack_v2_notifications" {
+  // user_id is still required with account-level Slack, same as V1
+  user_id    = 200
+  on_failure = [23456, 56788]
+  on_cancel  = [dbtcloud_job.prod_job.id]
+  // the Type 5 is used for Slack notifications via the account-level (V2) integration
+  notification_type  = 5
   slack_channel_id   = "C12345ABCDE"
   slack_channel_name = "#my-awesome-channel"
 }
@@ -67,7 +79,7 @@ resource "dbtcloud_notification" "prod_job_slack_notifications" {
 ### Optional
 
 - `external_email` (String) The external email to receive the notification
-- `notification_type` (Number) Type of notification (1 = dbt Cloud user email (default): does not require an external_email ; 2 = Slack channel: requires `slack_channel_id` and `slack_channel_name` ; 4 = external email: requires setting an `external_email`)
+- `notification_type` (Number) Type of notification (1 = dbt Cloud user email (default): does not require an external_email ; 2 = Slack channel (legacy, uses the per-user Slack integration of `user_id`): requires `slack_channel_id` ; 4 = external email: requires setting an `external_email` ; 5 = Slack channel using the account-level Slack (V2) integration: requires `slack_channel_id`, and the account-level Slack integration must be enabled on the account)
 - `on_cancel` (Set of Number) List of job IDs to trigger the webhook on cancel
 - `on_failure` (Set of Number) List of job IDs to trigger the webhook on failure
 - `on_success` (Set of Number) List of job IDs to trigger the webhook on success

--- a/docs/resources/partial_notification.md
+++ b/docs/resources/partial_notification.md
@@ -82,7 +82,7 @@ resource "dbtcloud_partial_notification" "prod_job_slack_notifications" {
 ### Optional
 
 - `external_email` (String) The external email to receive the notification [global, used as identifier]
-- `notification_type` (Number) Type of notification (1 = dbt Cloud user email (default): does not require an external_email ; 2 = Slack channel: requires `slack_channel_id` and `slack_channel_name` ; 4 = external email: requires setting an `external_email`) [global, used as identifier]
+- `notification_type` (Number) Type of notification (1 = dbt Cloud user email (default): does not require an external_email ; 2 = Slack channel (legacy, uses the per-user Slack integration of `user_id`): requires `slack_channel_id` ; 4 = external email: requires setting an `external_email` ; 5 = Slack channel using the account-level Slack (V2) integration: requires `slack_channel_id`, and the account-level Slack integration must be enabled on the account) [global, used as identifier]
 - `on_cancel` (Set of Number) List of job IDs to trigger the webhook on cancel. Those will be added/removed when config is added/removed.
 - `on_failure` (Set of Number) List of job IDs to trigger the webhook on failure Those will be added/removed when config is added/removed.
 - `on_success` (Set of Number) List of job IDs to trigger the webhook on success Those will be added/removed when config is added/removed.

--- a/examples/resources/dbtcloud_notification/resource.tf
+++ b/examples/resources/dbtcloud_notification/resource.tf
@@ -29,7 +29,7 @@ resource "dbtcloud_notification" "prod_job_external_notification" {
   external_email = "my_email@mail.com"
 }
 
-// and finally, we can set up Slack notifications
+// we can set up Slack notifications using the legacy, per-user Slack integration
 resource "dbtcloud_notification" "prod_job_slack_notifications" {
   // we need the ID of the user that set up the Slack Integration to properly send notifications
   user_id    = 200
@@ -37,6 +37,18 @@ resource "dbtcloud_notification" "prod_job_slack_notifications" {
   on_cancel  = [dbtcloud_job.prod_job.id]
   // the Type 2 is used for Slack notifications
   notification_type  = 2
+  slack_channel_id   = "C12345ABCDE"
+  slack_channel_name = "#my-awesome-channel"
+}
+
+// or we can use the account-level Slack (V2) integration set up via OAuth
+resource "dbtcloud_notification" "prod_job_slack_v2_notifications" {
+  // user_id is still required with account-level Slack, same as V1
+  user_id    = 200
+  on_failure = [23456, 56788]
+  on_cancel  = [dbtcloud_job.prod_job.id]
+  // the Type 5 is used for Slack notifications via the account-level (V2) integration
+  notification_type  = 5
   slack_channel_id   = "C12345ABCDE"
   slack_channel_name = "#my-awesome-channel"
 }

--- a/pkg/framework/objects/notification/resource.go
+++ b/pkg/framework/objects/notification/resource.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
@@ -10,6 +11,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// notificationErrorDetail augments a create/update error with actionable
+// guidance for notification_type 5 (Slack V2). That type is only accepted when
+// the account-level Slack integration is enabled on the account; when it is
+// not, the API rejects the write with a not-found response, which is otherwise
+// confusing on a create or an in-place type change.
+func notificationErrorDetail(notificationType int64, err error) string {
+	detail := "Error: " + err.Error()
+	if notificationType == 5 && strings.Contains(err.Error(), "resource-not-found") {
+		detail += "\n\nnotification_type = 5 uses the account-level Slack (V2) integration. " +
+			"A not-found response here usually means the Slack (V2) integration is not enabled for this account. " +
+			"Confirm the account-level Slack integration is configured before using notification_type = 5."
+	}
+	return detail
+}
 
 var (
 	_ resource.Resource                   = &notificationResource{}
@@ -56,13 +72,11 @@ func (r *notificationResource) ValidateConfig(
 		)
 	}
 
-	if data.NotificationType == types.Int64Value(2) &&
-		data.SlackChannelID.IsNull() &&
-		data.SlackChannelName.IsNull() {
+	if data.NotificationType == types.Int64Value(2) && data.SlackChannelID.IsNull() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("notification_type"),
 			"Notification type is not compatible with the other attributes",
-			"Notification type 2 requires a Slack channel ID and Slack channel name.",
+			"Notification type 2 requires a Slack channel ID.",
 		)
 	}
 
@@ -71,6 +85,14 @@ func (r *notificationResource) ValidateConfig(
 			path.Root("notification_type"),
 			"Notification type is not compatible with the other attributes",
 			"Notification type 4 requires an external email.",
+		)
+	}
+
+	if data.NotificationType == types.Int64Value(5) && data.SlackChannelID.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("notification_type"),
+			"Notification type is not compatible with the other attributes",
+			"Notification type 5 (Slack V2) requires a Slack channel ID.",
 		)
 	}
 }
@@ -176,7 +198,7 @@ func (r *notificationResource) Create(
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create notification",
-			"Error: "+err.Error(),
+			notificationErrorDetail(data.NotificationType.ValueInt64(), err),
 		)
 		return
 	}
@@ -275,7 +297,10 @@ func (r *notificationResource) Update(
 	// Update the notification
 	_, err := r.client.UpdateNotification(state.ID.ValueString(), notification)
 	if err != nil {
-		resp.Diagnostics.AddError("Error updating notification", err.Error())
+		resp.Diagnostics.AddError(
+			"Error updating notification",
+			notificationErrorDetail(state.NotificationType.ValueInt64(), err),
+		)
 		return
 	}
 

--- a/pkg/framework/objects/notification/resource_acceptance_test.go
+++ b/pkg/framework/objects/notification/resource_acceptance_test.go
@@ -168,9 +168,9 @@ func TestAccDbtCloudNotificationResource(t *testing.T) {
 }
 
 // TestAccDbtCloudNotificationResourceValidation exercises the config-time
-// validation for notification_type. These steps fail during plan (ValidateConfig
-// and the OneOf validator), so they do not require the account-level Slack
-// integration to be configured and never hit the create API.
+// validation for notification_type. These steps fail during plan (ValidateConfig),
+// so they do not require the account-level Slack integration to be configured
+// and never hit the create API.
 func TestAccDbtCloudNotificationResourceValidation(t *testing.T) {
 	userID := acctest_config.AcceptanceTestConfig.DbtCloudUserId
 
@@ -190,17 +190,6 @@ resource "dbtcloud_notification" "test_notification_slack_v2_invalid" {
 				ExpectError: regexp.MustCompile(
 					`Notification type 5 \(Slack V2\) requires a Slack channel ID`,
 				),
-			},
-			{
-				// an unsupported notification_type is rejected by the OneOf validator
-				Config: fmt.Sprintf(`
-resource "dbtcloud_notification" "test_notification_invalid_type" {
-	user_id           = %d
-	on_failure        = [12345]
-	notification_type = 3
-}
-`, userID),
-				ExpectError: regexp.MustCompile(`must be one of`),
 			},
 		},
 	})

--- a/pkg/framework/objects/notification/resource_acceptance_test.go
+++ b/pkg/framework/objects/notification/resource_acceptance_test.go
@@ -167,6 +167,45 @@ func TestAccDbtCloudNotificationResource(t *testing.T) {
 	})
 }
 
+// TestAccDbtCloudNotificationResourceValidation exercises the config-time
+// validation for notification_type. These steps fail during plan (ValidateConfig
+// and the OneOf validator), so they do not require the account-level Slack
+// integration to be configured and never hit the create API.
+func TestAccDbtCloudNotificationResourceValidation(t *testing.T) {
+	userID := acctest_config.AcceptanceTestConfig.DbtCloudUserId
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// type 5 without a Slack channel is rejected by ValidateConfig
+				Config: fmt.Sprintf(`
+resource "dbtcloud_notification" "test_notification_slack_v2_invalid" {
+	user_id           = %d
+	on_failure        = [12345]
+	notification_type = 5
+}
+`, userID),
+				ExpectError: regexp.MustCompile(
+					`Notification type 5 \(Slack V2\) requires a Slack channel ID`,
+				),
+			},
+			{
+				// an unsupported notification_type is rejected by the OneOf validator
+				Config: fmt.Sprintf(`
+resource "dbtcloud_notification" "test_notification_invalid_type" {
+	user_id           = %d
+	on_failure        = [12345]
+	notification_type = 3
+}
+`, userID),
+				ExpectError: regexp.MustCompile(`must be one of`),
+			},
+		},
+	})
+}
+
 func testAccDbtCloudNotificationResourceBasicConfig(projectName string) string {
 	return fmt.Sprintf(`
 resource "dbtcloud_project" "test_notification_project" {

--- a/pkg/framework/objects/notification/schema.go
+++ b/pkg/framework/objects/notification/schema.go
@@ -77,7 +77,7 @@ func (r *notificationResource) Schema(
 				Optional:    true,
 				Computed:    true,
 				Default:     int64default.StaticInt64(1),
-				Description: "Type of notification (1 = dbt Cloud user email (default): does not require an external_email ; 2 = Slack channel: requires `slack_channel_id` and `slack_channel_name` ; 4 = external email: requires setting an `external_email`)",
+				Description: "Type of notification (1 = dbt Cloud user email (default): does not require an external_email ; 2 = Slack channel (legacy, uses the per-user Slack integration of `user_id`): requires `slack_channel_id` ; 4 = external email: requires setting an `external_email` ; 5 = Slack channel using the account-level Slack (V2) integration: requires `slack_channel_id`, and the account-level Slack integration must be enabled on the account)",
 			},
 			"external_email": schema.StringAttribute{
 				Optional:    true,

--- a/pkg/framework/objects/partial_notification/resource.go
+++ b/pkg/framework/objects/partial_notification/resource.go
@@ -3,6 +3,7 @@ package partial_notification
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/objects/notification"
@@ -12,6 +13,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/samber/lo"
 )
+
+func partialNotificationErrorDetail(notificationType int64, err error) string {
+	detail := "Error: " + err.Error()
+	if notificationType == 5 && strings.Contains(err.Error(), "resource-not-found") {
+		detail += "\n\nnotification_type = 5 uses the account-level Slack (V2) integration. " +
+			"A not-found response here usually means the Slack (V2) integration is not enabled for this account. " +
+			"Confirm the account-level Slack integration is configured before using notification_type = 5."
+	}
+	return detail
+}
 
 var (
 	_ resource.Resource              = &partialNotificationResource{}
@@ -56,13 +67,11 @@ func (r *partialNotificationResource) ValidateConfig(
 		)
 	}
 
-	if data.NotificationType == types.Int64Value(2) &&
-		data.SlackChannelID.IsNull() &&
-		data.SlackChannelName.IsNull() {
+	if data.NotificationType == types.Int64Value(2) && data.SlackChannelID.IsNull() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("notification_type"),
 			"Notification type is not compatible with the other attributes",
-			"Notification type 2 requires a Slack channel ID and Slack channel name.",
+			"Notification type 2 requires a Slack channel ID.",
 		)
 	}
 
@@ -71,6 +80,14 @@ func (r *partialNotificationResource) ValidateConfig(
 			path.Root("notification_type"),
 			"Notification type is not compatible with the other attributes",
 			"Notification type 4 requires an external email.",
+		)
+	}
+
+	if data.NotificationType == types.Int64Value(5) && data.SlackChannelID.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("notification_type"),
+			"Notification type is not compatible with the other attributes",
+			"Notification type 5 (Slack V2) requires a Slack channel ID.",
 		)
 	}
 }
@@ -275,7 +292,7 @@ func (r *partialNotificationResource) Create(
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Unable to update the existing notification",
-					"Error: "+err.Error(),
+					partialNotificationErrorDetail(plan.NotificationType.ValueInt64(), err),
 				)
 				return
 			}
@@ -300,7 +317,7 @@ func (r *partialNotificationResource) Create(
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to create notification",
-				"Error: "+err.Error(),
+				partialNotificationErrorDetail(plan.NotificationType.ValueInt64(), err),
 			)
 			return
 		}
@@ -477,7 +494,7 @@ func (r *partialNotificationResource) Update(
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to update the existing notification",
-				"Error: "+err.Error(),
+				partialNotificationErrorDetail(plan.NotificationType.ValueInt64(), err),
 			)
 			return
 		}

--- a/pkg/framework/objects/partial_notification/schema.go
+++ b/pkg/framework/objects/partial_notification/schema.go
@@ -94,7 +94,7 @@ func (r *partialNotificationResource) Schema(
 				Optional:    true,
 				Computed:    true,
 				Default:     int64default.StaticInt64(1),
-				Description: "Type of notification (1 = dbt Cloud user email (default): does not require an external_email ; 2 = Slack channel: requires `slack_channel_id` and `slack_channel_name` ; 4 = external email: requires setting an `external_email`) [global, used as identifier]",
+				Description: "Type of notification (1 = dbt Cloud user email (default): does not require an external_email ; 2 = Slack channel (legacy, uses the per-user Slack integration of `user_id`): requires `slack_channel_id` ; 4 = external email: requires setting an `external_email` ; 5 = Slack channel using the account-level Slack (V2) integration: requires `slack_channel_id`, and the account-level Slack integration must be enabled on the account) [global, used as identifier]",
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
 				},


### PR DESCRIPTION
Problem:
Users were unaware of how to use the TF provider to provision Slack V2 notifications.

Solution:
Add documentation for Slack V2 and validations for the required fields to `dbtcloud_notification` and `dbtcloud_partial_notification`.