### PR TITLE
Bugfixes for 1.12.4

### DIFF
--- a/.changes/unreleased/Fixes-20260629-154108.yaml
+++ b/.changes/unreleased/Fixes-20260629-154108.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Fix issues with BQ WIF
+time: 2026-06-29T15:41:08.833164+03:00

--- a/docs/data-sources/bigquery_credential.md
+++ b/docs/data-sources/bigquery_credential.md
@@ -22,7 +22,10 @@ Bigquery credential data source
 
 ### Read-Only
 
+- `auth_type` (String) The authentication method for the BigQuery credential
 - `dataset` (String) Default dataset name
 - `id` (String) The ID of this data source. Contains the project ID and the credential ID.
 - `is_active` (Boolean) Whether the BigQuery credential is active
 - `num_threads` (Number) Number of threads to use
+- `service_account_impersonation_url` (String) The URL for the service account impersonation request
+- `workload_pool_provider_path` (String) The fully specified resource name of the workload pool provider

--- a/docs/resources/bigquery_credential.md
+++ b/docs/resources/bigquery_credential.md
@@ -40,8 +40,11 @@ resource "dbtcloud_bigquery_credential" "my_credential_v1" {
 
 ### Optional
 
+- `auth_type` (String) The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
 - `connection_id` (Number) The ID of the global connection to use for this credential. When provided, the credential will automatically use the correct adapter version based on the connection's configuration (e.g., bigquery_v1 for connections with use_latest_adapter=true).
 - `is_active` (Boolean) Whether the BigQuery credential is active
+- `service_account_impersonation_url` (String) The URL for the service account impersonation request, used when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
+- `workload_pool_provider_path` (String) The fully specified resource name of the workload pool provider, required when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
 
 ### Read-Only
 

--- a/docs/resources/bigquery_semantic_layer_credential.md
+++ b/docs/resources/bigquery_semantic_layer_credential.md
@@ -84,8 +84,11 @@ Required:
 
 Optional:
 
+- `auth_type` (String) The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
 - `connection_id` (Number) The ID of the global connection to use for this credential. When provided, the credential will automatically use the correct adapter version based on the connection's configuration (e.g., bigquery_v1 for connections with use_latest_adapter=true).
 - `is_active` (Boolean) Whether the BigQuery credential is active
+- `service_account_impersonation_url` (String) The URL for the service account impersonation request, used when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
+- `workload_pool_provider_path` (String) The fully specified resource name of the workload pool provider, required when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
 
 Read-Only:
 

--- a/docs/resources/global_connection.md
+++ b/docs/resources/global_connection.md
@@ -190,7 +190,7 @@ resource "dbtcloud_global_connection" "teradata" {
 - `bigquery` (Attributes) (see [below for nested schema](#nestedatt--bigquery))
 - `databricks` (Attributes) Databricks connection configuration (see [below for nested schema](#nestedatt--databricks))
 - `fabric` (Attributes) Microsoft Fabric connection configuration. (see [below for nested schema](#nestedatt--fabric))
-- `oauth_configuration_id` (Number) External OAuth configuration ID (only Snowflake for now)
+- `oauth_configuration_id` (Number) External OAuth configuration ID. Supported for all connection types.
 - `postgres` (Attributes) PostgreSQL connection configuration. (see [below for nested schema](#nestedatt--postgres))
 - `private_link_endpoint_id` (String) Private Link Endpoint ID. This ID can be found using the `privatelink_endpoint` data source
 - `redshift` (Attributes) Redshift connection configuration (see [below for nested schema](#nestedatt--redshift))

--- a/pkg/dbt_cloud/bigquery_credential.go
+++ b/pkg/dbt_cloud/bigquery_credential.go
@@ -14,8 +14,11 @@ type BigQueryCredentialResponse struct {
 
 // BigQueryUnencryptedCredentialDetails contains the readable credential values for v1 credentials
 type BigQueryUnencryptedCredentialDetails struct {
-	Schema  string `json:"schema"`
-	Threads int    `json:"threads"`
+	Schema                        string `json:"schema"`
+	Threads                       int    `json:"threads"`
+	AuthType                      string `json:"auth_type,omitempty"`
+	WorkloadPoolProviderPath       string `json:"workload_pool_provider_path,omitempty"`
+	ServiceAccountImpersonationURL string `json:"service_account_impersonation_url,omitempty"`
 }
 
 type BigQueryCredential struct {
@@ -49,6 +52,30 @@ func (c *BigQueryCredential) GetThreads() int {
 	}
 	// For v0 credentials or if not found
 	return c.Threads
+}
+
+// GetAuthType returns the auth_type from unencrypted_credential_details (v1 only)
+func (c *BigQueryCredential) GetAuthType() string {
+	if c.UnencryptedCredentialDetails != nil {
+		return c.UnencryptedCredentialDetails.AuthType
+	}
+	return ""
+}
+
+// GetWorkloadPoolProviderPath returns the workload_pool_provider_path from unencrypted_credential_details (v1 only)
+func (c *BigQueryCredential) GetWorkloadPoolProviderPath() string {
+	if c.UnencryptedCredentialDetails != nil {
+		return c.UnencryptedCredentialDetails.WorkloadPoolProviderPath
+	}
+	return ""
+}
+
+// GetServiceAccountImpersonationURL returns the service_account_impersonation_url from unencrypted_credential_details (v1 only)
+func (c *BigQueryCredential) GetServiceAccountImpersonationURL() string {
+	if c.UnencryptedCredentialDetails != nil {
+		return c.UnencryptedCredentialDetails.ServiceAccountImpersonationURL
+	}
+	return ""
 }
 
 // BigQueryCredentialGlobConn is used for creating credentials with the new adapter format (bigquery_v1)
@@ -103,6 +130,9 @@ func (c *Client) CreateBigQueryCredential(
 	dataset string,
 	numThreads int,
 	adapterVersion string,
+	authType string,
+	workloadPoolProviderPath string,
+	serviceAccountImpersonationURL string,
 ) (*BigQueryCredential, error) {
 	var requestData []byte
 	var err error
@@ -110,7 +140,7 @@ func (c *Client) CreateBigQueryCredential(
 	// When adapter_version is provided, use the new adapter format with credential_details
 	// This is required for connections using use_latest_adapter=true (bigquery_v1)
 	if adapterVersion != "" {
-		credentialDetails, err := GenerateBigQueryCredentialDetails(dataset, numThreads)
+		credentialDetails, err := GenerateBigQueryCredentialDetails(dataset, numThreads, authType, workloadPoolProviderPath, serviceAccountImpersonationURL)
 		if err != nil {
 			return nil, err
 		}
@@ -173,62 +203,84 @@ func (c *Client) CreateBigQueryCredential(
 }
 
 // GenerateBigQueryCredentialDetails creates the credential_details structure for BigQuery v1 credentials
-func GenerateBigQueryCredentialDetails(dataset string, numThreads int) (AdapterCredentialDetails, error) {
-	// The credential_details structure for BigQuery follows the same pattern as other adapters
-	defaultConfig := `{
-	"fields": {
+func GenerateBigQueryCredentialDetails(
+	dataset string,
+	numThreads int,
+	authType string,
+	workloadPoolProviderPath string,
+	serviceAccountImpersonationURL string,
+) (AdapterCredentialDetails, error) {
+	fields := map[string]AdapterCredentialField{
 		"schema": {
-			"metadata": {
-				"label": "Dataset",
-				"description": "The default dataset to use for this credential",
-				"field_type": "text",
-				"encrypt": false,
-				"overrideable": false,
-				"validation": {
-					"required": true
-				}
+			Metadata: AdapterCredentialFieldMetadata{
+				Label:       "Dataset",
+				Description: "The default dataset to use for this credential",
+				Field_Type:  "text",
+				Encrypt:     false,
+				Validation:  AdapterCredentialFieldMetadataValidation{Required: true},
 			},
-			"value": ""
+			Value: dataset,
 		},
 		"threads": {
-			"metadata": {
-				"label": "Threads",
-				"description": "The number of threads to use",
-				"field_type": "number",
-				"encrypt": false,
-				"overrideable": false,
-				"validation": {
-					"required": true
-				}
+			Metadata: AdapterCredentialFieldMetadata{
+				Label:       "Threads",
+				Description: "The number of threads to use",
+				Field_Type:  "number",
+				Encrypt:     false,
+				Validation:  AdapterCredentialFieldMetadataValidation{Required: true},
 			},
-			"value": 4
+			Value: numThreads,
+		},
+	}
+
+	if authType != "" {
+		fields["auth_type"] = AdapterCredentialField{
+			Metadata: AdapterCredentialFieldMetadata{
+				Label:       "Authentication Method",
+				Description: "The authentication method to use for this credential.",
+				Field_Type:  "select",
+				Encrypt:     false,
+				Validation:  AdapterCredentialFieldMetadataValidation{Required: true},
+				Options: []AdapterCredentialFieldMetadataOptions{
+					{Label: "Service Account JSON", Value: "service-account-json"},
+					{Label: "Native OAuth", Value: "oauth-secrets"},
+					{Label: "Workload Identity Federation", Value: "external-oauth-wif"},
+				},
+			},
+			Value: authType,
 		}
 	}
-}`
 
-	var bigQueryCredentialDetailsDefault AdapterCredentialDetails
-	err := json.Unmarshal([]byte(defaultConfig), &bigQueryCredentialDetailsDefault)
-	if err != nil {
-		return bigQueryCredentialDetailsDefault, err
+	if workloadPoolProviderPath != "" {
+		fields["workload_pool_provider_path"] = AdapterCredentialField{
+			Metadata: AdapterCredentialFieldMetadata{
+				Label:       "Workload Pool Provider Path",
+				Description: "The fully specified resource name of the workload pool provider",
+				Field_Type:  "text",
+				Encrypt:     false,
+				Validation:  AdapterCredentialFieldMetadataValidation{Required: true},
+			},
+			Value: workloadPoolProviderPath,
+		}
 	}
 
-	fieldMapping := map[string]interface{}{
-		"schema":  dataset,
-		"threads": numThreads,
+	if serviceAccountImpersonationURL != "" {
+		fields["service_account_impersonation_url"] = AdapterCredentialField{
+			Metadata: AdapterCredentialFieldMetadata{
+				Label:       "Service Account Impersonation URL",
+				Description: "The URL for the service account impersonation request",
+				Field_Type:  "text",
+				Encrypt:     false,
+				Validation:  AdapterCredentialFieldMetadataValidation{Required: false},
+			},
+			Value: serviceAccountImpersonationURL,
+		}
 	}
 
-	bigQueryCredentialFields := map[string]AdapterCredentialField{}
-	for key, value := range bigQueryCredentialDetailsDefault.Fields {
-		field := value
-		field.Value = fieldMapping[key]
-		bigQueryCredentialFields[key] = field
-	}
-
-	credentialDetails := AdapterCredentialDetails{
-		Fields:      bigQueryCredentialFields,
+	return AdapterCredentialDetails{
+		Fields:      fields,
 		Field_Order: []string{},
-	}
-	return credentialDetails, nil
+	}, nil
 }
 
 func (c *Client) UpdateBigQueryCredential(

--- a/pkg/dbt_cloud/notification_setting_test.go
+++ b/pkg/dbt_cloud/notification_setting_test.go
@@ -1,0 +1,101 @@
+package dbt_cloud
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newNotificationSettingTestClient builds a Client pointed at the provided
+// httptest.Server with retries disabled so the test does not block on backoff.
+func newNotificationSettingTestClient(t *testing.T, serverURL string) *Client {
+	t.Helper()
+	t.Setenv("TF_ACC", "1") // skip credential validation in NewClient
+
+	accountID := int64(123)
+	token := "test_token"
+	maxRetries := 1
+	retryInterval := 0
+	timeout := 5
+	skipValidation := true
+
+	c, err := NewClient(
+		&accountID,
+		&token,
+		&serverURL,
+		&maxRetries,
+		&retryInterval,
+		nil,
+		skipValidation,
+		&timeout,
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+// TestDeleteNotificationSetting_NotFoundIsResourceNotFoundPrefixed verifies the
+// contract the framework Delete relies on: when the notification-settings
+// DELETE comes back as a 404 (the row is already gone), the client returns an
+// error whose message starts with "resource-not-found". The framework resource
+// uses strings.HasPrefix(err.Error(), "resource-not-found") to treat the
+// destroy as successful, so both the plain and permission-flavored 404
+// responses must keep that prefix or the spurious "Error deleting notification
+// setting" diagnostic returns and turns CI runs red.
+func TestDeleteNotificationSetting_NotFoundIsResourceNotFoundPrefixed(t *testing.T) {
+	cases := []struct {
+		name        string
+		userMessage string
+	}{
+		{
+			name:        "plain 404",
+			userMessage: "The requested resource was not found.",
+		},
+		{
+			name:        "404 with permission hint",
+			userMessage: "The requested resource was not found. Please check that you have the proper permissions.",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete {
+					t.Errorf("expected DELETE, got %s", r.Method)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"data":null,"status":{"code":404,"is_success":false,"user_message":"` + tc.userMessage + `","developer_message":""}}`))
+			}))
+			defer srv.Close()
+
+			c := newNotificationSettingTestClient(t, srv.URL)
+
+			err := c.DeleteNotificationSetting(42)
+			if err == nil {
+				t.Fatalf("expected an error from a 404 delete, got nil")
+			}
+			if !strings.HasPrefix(err.Error(), "resource-not-found") {
+				t.Fatalf("expected error to start with %q so the framework Delete guard tolerates it, got: %v", "resource-not-found", err)
+			}
+		})
+	}
+}
+
+// TestDeleteNotificationSetting_SuccessReturnsNil verifies a normal 2xx delete
+// returns no error.
+func TestDeleteNotificationSetting_SuccessReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newNotificationSettingTestClient(t, srv.URL)
+
+	if err := c.DeleteNotificationSetting(42); err != nil {
+		t.Fatalf("expected nil error on successful delete, got: %v", err)
+	}
+}

--- a/pkg/framework/objects/bigquery_credential/data_source.go
+++ b/pkg/framework/objects/bigquery_credential/data_source.go
@@ -100,6 +100,22 @@ func (d *bigqueryCredentialDataSource) Read(
 	state.NumThreads = types.Int64Value(int64(credential.GetThreads()))
 	state.IsActive = types.BoolValue(credential.State == dbt_cloud.STATE_ACTIVE)
 	state.ProjectID = types.Int64Value(int64(credential.Project_Id))
+	// WIF fields (v1 only; null when not set)
+	if v := credential.GetAuthType(); v != "" {
+		state.AuthType = types.StringValue(v)
+	} else {
+		state.AuthType = types.StringNull()
+	}
+	if v := credential.GetWorkloadPoolProviderPath(); v != "" {
+		state.WorkloadPoolProviderPath = types.StringValue(v)
+	} else {
+		state.WorkloadPoolProviderPath = types.StringNull()
+	}
+	if v := credential.GetServiceAccountImpersonationURL(); v != "" {
+		state.ServiceAccountImpersonationURL = types.StringValue(v)
+	} else {
+		state.ServiceAccountImpersonationURL = types.StringNull()
+	}
 
 	// Set state
 	diags = resp.State.Set(ctx, &state)

--- a/pkg/framework/objects/bigquery_credential/model.go
+++ b/pkg/framework/objects/bigquery_credential/model.go
@@ -6,21 +6,27 @@ import (
 
 // BigqueryCredentialResourceModel is the model for the resource
 type BigqueryCredentialResourceModel struct {
-	ID           types.String `tfsdk:"id"`
-	CredentialID types.Int64  `tfsdk:"credential_id"`
-	ProjectID    types.Int64  `tfsdk:"project_id"`
-	IsActive     types.Bool   `tfsdk:"is_active"`
-	Dataset      types.String `tfsdk:"dataset"`
-	NumThreads   types.Int64  `tfsdk:"num_threads"`
-	ConnectionID types.Int64  `tfsdk:"connection_id"`
+	ID                             types.String `tfsdk:"id"`
+	CredentialID                   types.Int64  `tfsdk:"credential_id"`
+	ProjectID                      types.Int64  `tfsdk:"project_id"`
+	IsActive                       types.Bool   `tfsdk:"is_active"`
+	Dataset                        types.String `tfsdk:"dataset"`
+	NumThreads                     types.Int64  `tfsdk:"num_threads"`
+	ConnectionID                   types.Int64  `tfsdk:"connection_id"`
+	AuthType                       types.String `tfsdk:"auth_type"`
+	WorkloadPoolProviderPath       types.String `tfsdk:"workload_pool_provider_path"`
+	ServiceAccountImpersonationURL types.String `tfsdk:"service_account_impersonation_url"`
 }
 
 // BigqueryCredentialDataSourceModel is the model for the data source
 type BigqueryCredentialDataSourceModel struct {
-	ID           types.String `tfsdk:"id"`
-	CredentialID types.Int64  `tfsdk:"credential_id"`
-	ProjectID    types.Int64  `tfsdk:"project_id"`
-	IsActive     types.Bool   `tfsdk:"is_active"`
-	Dataset      types.String `tfsdk:"dataset"`
-	NumThreads   types.Int64  `tfsdk:"num_threads"`
+	ID                             types.String `tfsdk:"id"`
+	CredentialID                   types.Int64  `tfsdk:"credential_id"`
+	ProjectID                      types.Int64  `tfsdk:"project_id"`
+	IsActive                       types.Bool   `tfsdk:"is_active"`
+	Dataset                        types.String `tfsdk:"dataset"`
+	NumThreads                     types.Int64  `tfsdk:"num_threads"`
+	AuthType                       types.String `tfsdk:"auth_type"`
+	WorkloadPoolProviderPath       types.String `tfsdk:"workload_pool_provider_path"`
+	ServiceAccountImpersonationURL types.String `tfsdk:"service_account_impersonation_url"`
 }

--- a/pkg/framework/objects/bigquery_credential/resource.go
+++ b/pkg/framework/objects/bigquery_credential/resource.go
@@ -91,6 +91,9 @@ func (r *bigqueryCredentialResource) Create(
 	projectID := int(plan.ProjectID.ValueInt64())
 	dataset := plan.Dataset.ValueString()
 	numThreads := int(plan.NumThreads.ValueInt64())
+	authType := plan.AuthType.ValueString()
+	workloadPoolProviderPath := plan.WorkloadPoolProviderPath.ValueString()
+	serviceAccountImpersonationURL := plan.ServiceAccountImpersonationURL.ValueString()
 
 	// Auto-detect adapter version from the connection if connection_id is provided
 	var adapterVersion string
@@ -115,6 +118,9 @@ func (r *bigqueryCredentialResource) Create(
 		dataset,
 		numThreads,
 		adapterVersion,
+		authType,
+		workloadPoolProviderPath,
+		serviceAccountImpersonationURL,
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -174,6 +180,22 @@ func (r *bigqueryCredentialResource) Read(
 	// Use helper methods to get dataset and threads from the correct location (v0 vs v1)
 	state.Dataset = types.StringValue(credential.GetDataset())
 	state.NumThreads = types.Int64Value(int64(credential.GetThreads()))
+	// WIF fields (v1 only; null when not set to avoid perpetual diffs)
+	if v := credential.GetAuthType(); v != "" {
+		state.AuthType = types.StringValue(v)
+	} else {
+		state.AuthType = types.StringNull()
+	}
+	if v := credential.GetWorkloadPoolProviderPath(); v != "" {
+		state.WorkloadPoolProviderPath = types.StringValue(v)
+	} else {
+		state.WorkloadPoolProviderPath = types.StringNull()
+	}
+	if v := credential.GetServiceAccountImpersonationURL(); v != "" {
+		state.ServiceAccountImpersonationURL = types.StringValue(v)
+	} else {
+		state.ServiceAccountImpersonationURL = types.StringNull()
+	}
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)

--- a/pkg/framework/objects/bigquery_credential/schema.go
+++ b/pkg/framework/objects/bigquery_credential/schema.go
@@ -59,6 +59,27 @@ var BigQueryResourceSchema = resource_schema.Schema{
 				int64planmodifier.RequiresReplace(),
 			},
 		},
+		"auth_type": resource_schema.StringAttribute{
+			Optional:    true,
+			Description: "The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"workload_pool_provider_path": resource_schema.StringAttribute{
+			Optional:    true,
+			Description: "The fully specified resource name of the workload pool provider, required when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"service_account_impersonation_url": resource_schema.StringAttribute{
+			Optional:    true,
+			Description: "The URL for the service account impersonation request, used when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
 	},
 }
 
@@ -88,6 +109,18 @@ var datasourceSchema = datasource_schema.Schema{
 		"num_threads": datasource_schema.Int64Attribute{
 			Computed:    true,
 			Description: "Number of threads to use",
+		},
+		"auth_type": datasource_schema.StringAttribute{
+			Computed:    true,
+			Description: "The authentication method for the BigQuery credential",
+		},
+		"workload_pool_provider_path": datasource_schema.StringAttribute{
+			Computed:    true,
+			Description: "The fully specified resource name of the workload pool provider",
+		},
+		"service_account_impersonation_url": datasource_schema.StringAttribute{
+			Computed:    true,
+			Description: "The URL for the service account impersonation request",
 		},
 	},
 }

--- a/pkg/framework/objects/global_connection/common.go
+++ b/pkg/framework/objects/global_connection/common.go
@@ -712,6 +712,18 @@ func readGeneric(
 		state.Name = types.StringPointerValue(common.Name)
 		state.IsSshTunnelEnabled = types.BoolPointerValue(common.IsSshTunnelEnabled)
 
+		// nullable common fields
+		if !common.PrivateLinkEndpointId.IsNull() {
+			state.PrivateLinkEndpointId = types.StringValue(common.PrivateLinkEndpointId.MustGet())
+		} else {
+			state.PrivateLinkEndpointId = types.StringNull()
+		}
+		if !common.OauthConfigurationId.IsNull() {
+			state.OauthConfigurationId = types.Int64Value(common.OauthConfigurationId.MustGet())
+		} else {
+			state.OauthConfigurationId = types.Int64Null()
+		}
+
 		// Teradata settings
 		state.TeradataConfig.Host = types.StringPointerValue(teradataCfg.Host)
 		state.TeradataConfig.Port = types.StringPointerValue(teradataCfg.Port)

--- a/pkg/framework/objects/global_connection/schema.go
+++ b/pkg/framework/objects/global_connection/schema.go
@@ -59,7 +59,7 @@ func (r *globalConnectionResource) Schema(
 			},
 			"oauth_configuration_id": resource_schema.Int64Attribute{
 				Optional:    true,
-				Description: "External OAuth configuration ID (only Snowflake for now)",
+				Description: "External OAuth configuration ID. Supported for all connection types.",
 			},
 			"bigquery": resource_schema.SingleNestedAttribute{
 				Optional: true,

--- a/pkg/framework/objects/notification_setting/resource.go
+++ b/pkg/framework/objects/notification_setting/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
@@ -126,6 +127,15 @@ func (r *notificationSettingResource) Delete(
 	}
 
 	if err := r.client.DeleteNotificationSetting(state.ID.ValueInt64()); err != nil {
+		// The notification-settings DELETE removes the integration but can come
+		// back as a 404-style response (e.g. "resource-not-found" or
+		// "resource-not-found-permissions") when the row is already gone. Treat
+		// not-found as success and let the resource drop from state instead of
+		// failing the destroy — otherwise an already-completed delete turns CI
+		// runs red. Mirrors the databricks_credential delete path.
+		if strings.HasPrefix(err.Error(), "resource-not-found") {
+			return
+		}
 		resp.Diagnostics.AddError("Error deleting notification setting", err.Error())
 		return
 	}


### PR DESCRIPTION
## Summary

Three independent bug fixes for the `1.12.4` release, each in its own commit:

1. **`dbtcloud_notification_setting`** — destroy no longer fails when the setting is already gone.
2. **`dbtcloud_bigquery_credential`** — adds the fields needed for BigQuery Workload Identity Federation (WIF). Resolves #706.
3. **`dbtcloud_global_connection`** — `oauth_configuration_id` is now usable for all connection types (not just Snowflake). Resolves #705.

Each change is reviewable as a separate commit.

---

### 1. Fix `notification_setting` destroy failing on not-found

Destroying a `dbtcloud_notification_setting` could fail with `resource-not-found-permissions` even though the integration was actually deleted, turning customer CI runs red. The delete path surfaced any client error as a hard diagnostic instead of treating a not-found response as success.

The `Delete` method now tolerates a `resource-not-found`-prefixed error and lets the resource drop from state — the same pattern already used by `dbtcloud_databricks_credential`. This also covers the `resource-not-found-permissions` variant the dbt platform API returns when the row is already gone (e.g. a retried destroy).

**Files**
- `pkg/framework/objects/notification_setting/resource.go`
- `pkg/dbt_cloud/notification_setting_test.go` (new)

### 2. Add BigQuery WIF fields to `bigquery_credential` (#706)

`dbtcloud_bigquery_credential` was missing the fields required to create a credential that uses Workload Identity Federation, so WIF-based setups couldn't be fully managed in Terraform. Adds:

- `auth_type` — `service-account-json`, `oauth-secrets`, or `external-oauth-wif`
- `workload_pool_provider_path` — required when `auth_type` is `external-oauth-wif`
- `service_account_impersonation_url` — used with `external-oauth-wif`

These apply to v1 credentials (when `connection_id` is set) and are exposed on both the resource and the data source.

**Files**
- `pkg/dbt_cloud/bigquery_credential.go`
- `pkg/framework/objects/bigquery_credential/{model,schema,resource,data_source}.go`

### 3. Support `oauth_configuration_id` for all connection types in `global_connection` (#705)

`oauth_configuration_id` was documented and wired up for Snowflake only, which blocked BigQuery WIF global connections from linking their OAuth integration. The attribute now applies to all connection types, and the generic read path populates the nullable common fields (`oauth_configuration_id`, `private_link_endpoint_id`) so they round-trip correctly.

**Files**
- `pkg/framework/objects/global_connection/schema.go`
- `pkg/framework/objects/global_connection/common.go`

---

### Testing

- `go build ./...` and `go vet ./...`
- `go test ./pkg/dbt_cloud/ -run TestDeleteNotificationSetting -v` for the delete fix
- Acceptance tests for the affected resources (`TF_ACC=1`)

### Related issues

- Resolves #705
- Resolves #706
