### PR TITLE
fix: spurious in-place update on dbtcloud_postgres_credential.id

### DIFF
--- a/.changes/unreleased/Fixes-20260803-132946.yaml
+++ b/.changes/unreleased/Fixes-20260803-132946.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Add `UseStateForUnknown()` to `dbtcloud_postgres_credential`'s `id` attribute so `terraform plan` no longer shows a spurious in-place update on every run when using `password_wo` (#719).
+time: 2026-08-03T13:29:46.014118+03:00

--- a/pkg/framework/objects/postgres_credential/behavior_test.go
+++ b/pkg/framework/objects/postgres_credential/behavior_test.go
@@ -1,0 +1,72 @@
+package postgres_credential
+
+import (
+	"context"
+	"testing"
+
+	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestIDAttribute_UseStateForUnknown is a regression test for #719: the "id"
+// attribute had no PlanModifiers, so it was always recomputed as unknown
+// whenever the resource was touched for an update (e.g. one triggered by
+// bumping password_wo_version), even though id is deterministically derived
+// from project_id and credential_id and never actually changes. That surfaced
+// as a spurious "id = ... -> (known after apply)" in-place update on every
+// terraform plan.
+func TestIDAttribute_UseStateForUnknown(t *testing.T) {
+	attr, ok := PostgresResourceSchema.Attributes["id"].(resource_schema.StringAttribute)
+	if !ok {
+		t.Fatalf("id attribute is not a resource_schema.StringAttribute")
+	}
+	if len(attr.PlanModifiers) == 0 {
+		t.Fatalf("regression: id attribute has no plan modifiers, so terraform will always recompute it as unknown")
+	}
+
+	// Build a real prior state matching the full resource schema: the plan
+	// modifier bails out early if req.State.Raw is null, so a bare
+	// StringRequest{StateValue: ...} isn't enough to exercise it faithfully.
+	priorState := &PostgresCredentialResourceModel{
+		ID:                      types.StringValue("5:10"),
+		ProjectID:               types.Int64Value(5),
+		CredentialID:            types.Int64Value(10),
+		IsActive:                types.BoolValue(true),
+		DefaultSchema:           types.StringValue("default_schema"),
+		Username:                types.StringValue("user"),
+		NumThreads:              types.Int64Value(0),
+		Type:                    types.StringValue("postgres"),
+		TargetName:              types.StringValue("default"),
+		Password:                types.StringNull(),
+		PasswordWo:              types.StringNull(),
+		PasswordWoVersion:       types.Int64Value(1),
+		SemanticLayerCredential: types.BoolValue(false),
+	}
+
+	tfState := tfsdk.State{Schema: PostgresResourceSchema}
+	if diags := tfState.Set(context.Background(), priorState); diags.HasError() {
+		t.Fatalf("failed to build state fixture: %v", diags)
+	}
+
+	req := planmodifier.StringRequest{
+		State:       tfState,
+		StateValue:  types.StringValue("5:10"),
+		PlanValue:   types.StringUnknown(),
+		ConfigValue: types.StringNull(),
+	}
+
+	for _, pm := range attr.PlanModifiers {
+		resp := &planmodifier.StringResponse{PlanValue: req.PlanValue}
+		pm.PlanModifyString(context.Background(), req, resp)
+		req.PlanValue = resp.PlanValue
+	}
+
+	if req.PlanValue.IsUnknown() {
+		t.Fatalf("regression: id is still unknown after plan modification; terraform plan would show a spurious in-place update")
+	}
+	if req.PlanValue.ValueString() != "5:10" {
+		t.Fatalf("expected id to retain the prior state value %q, got %q", "5:10", req.PlanValue.ValueString())
+	}
+}

--- a/pkg/framework/objects/postgres_credential/schema.go
+++ b/pkg/framework/objects/postgres_credential/schema.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
@@ -57,6 +58,9 @@ var PostgresResourceSchema = resource_schema.Schema{
 		"id": resource_schema.StringAttribute{
 			Computed:    true,
 			Description: "The ID of this resource. Contains the project ID and the credential ID.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"is_active": resource_schema.BoolAttribute{
 			Optional:    true,


### PR DESCRIPTION
## Summary
- `id` in the `dbtcloud_postgres_credential` resource schema was missing `UseStateForUnknown()`, unlike `credential_id` in the same schema and the `id` attribute of every other resource in this provider.
- Since `id` is deterministically derived from `project_id` and `credential_id` (both already stable/known), it never needs to be recomputed as unknown. The missing plan modifier caused `terraform plan` to always show a no-op in-place update whenever the resource used `password_wo` — the only visible line in the diff being `id = "..." -> (known after apply)`.
- Fix: add `UseStateForUnknown()` to the `id` attribute, matching the rest of the provider.

## Verification
Also confirmed live against a real dbt Cloud backend (personal devspace):
- Built the pre-fix (`main`) provider, applied a `postgres_credential` using `password_wo`, then ran `plan` again with no config changes — reproduced the exact bug (`id = "160:227" -> (known after apply)`, planned as an update).
- Rebuilt with this fix, ran `plan` again on the same state — confirmed via the plan JSON diff that `id` is now identical before/after with no change proposed for it.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/framework/objects/postgres_credential/...` (acceptance tests skip without `TF_ACC`, package compiles and unit-level checks pass)
- [x] Live-tested against a real dbt Cloud backend (see Verification above)

Closes #719
