### PR TITLE
fix: make dbtcloud_notification_setting delete idempotent on 404

### DIFF
--- a/.changes/unreleased/Fixes-20260803-132948.yaml
+++ b/.changes/unreleased/Fixes-20260803-132948.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: 'Make `dbtcloud_notification_setting` deletion idempotent: a 404 from the delete API is now treated as success instead of failing the apply (#718).'
+time: 2026-08-03T13:29:48.533476+03:00

--- a/pkg/framework/objects/notification_setting/behavior_test.go
+++ b/pkg/framework/objects/notification_setting/behavior_test.go
@@ -1,0 +1,69 @@
+package notification_setting
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestDelete_404IsTreatedAsSuccess is a regression test for #718: Delete used
+// to surface any API error as a hard failure, including a 404 returned when
+// the notification setting was already gone server-side, which failed
+// terraform apply even though the resource had, in effect, been deleted.
+func TestDelete_404IsTreatedAsSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected request method %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"status": {"code": 404, "is_success": false, "user_message": "not found"}}`))
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	client := &dbt_cloud.Client{
+		HostURL:    u,
+		HTTPClient: server.Client(),
+		AccountID:  1,
+		MaxRetries: 1,
+	}
+
+	r := &notificationSettingResource{client: client}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema error: %v", schemaResp.Diagnostics)
+	}
+
+	model := &NotificationSettingResourceModel{
+		ID:          types.Int64Value(42),
+		Name:        types.StringValue("test-setting"),
+		Description: types.StringNull(),
+		Channels:    []NotificationSettingChannelModel{},
+		Rules:       []NotificationSettingRuleModel{},
+	}
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	if diags := state.Set(context.Background(), model); diags.HasError() {
+		t.Fatalf("failed to build state fixture: %v", diags)
+	}
+
+	resp := &resource.DeleteResponse{State: state}
+	r.Delete(context.Background(), resource.DeleteRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("regression: Delete failed on a 404 instead of treating it as an idempotent success: %v", resp.Diagnostics)
+	}
+}

--- a/pkg/framework/objects/notification_setting/resource.go
+++ b/pkg/framework/objects/notification_setting/resource.go
@@ -126,6 +126,10 @@ func (r *notificationSettingResource) Delete(
 	}
 
 	if err := r.client.DeleteNotificationSetting(state.ID.ValueInt64()); err != nil {
+		// If the resource is already deleted (404), treat as success
+		if helper.HandleResourceNotFound(ctx, err, &resp.Diagnostics, &resp.State, "notification setting") {
+			return
+		}
 		resp.Diagnostics.AddError("Error deleting notification setting", err.Error())
 		return
 	}


### PR DESCRIPTION
## Summary
- `Delete` on `dbtcloud_notification_setting` surfaced *any* API error as a hard failure, including a 404 returned when the resource is already gone server-side (reported as happening "sometimes" even though the delete had actually succeeded).
- This provider already has an established, tested pattern for exactly this case — `postgres_credential`, `spark_credential`, and `databricks_credential` all treat a `resource-not-found` error on delete as success via `helper.HandleResourceNotFound`. `notification_setting` was the outlier not using it.
- Fix: use `helper.HandleResourceNotFound` in `notification_setting`'s `Delete`, consistent with the rest of the provider, so a 404 no longer fails `terraform apply`.

## Verification
Also confirmed live against a real dbt Cloud backend (personal devspace), not just unit tests:
- `terraform apply` created a notification setting.
- Deleted it out-of-band via the API to simulate the "delete actually succeeded but client saw failure" scenario from the bug report.
- `terraform destroy` reported "no objects need to be destroyed" instead of erroring — confirmed both `Read` and `Delete` already handle the 404 correctly (no gap here, unlike the related fix in #724 where `Read` was missing this).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/framework/objects/notification_setting/...` (acceptance tests skip without `TF_ACC`, package compiles and unit-level checks pass)
- [x] Live-tested against a real dbt Cloud backend (see Verification above)

Closes #718
