### PR TITLE
fix: treat 404 on environment delete as idempotent success

### DIFF
--- a/.changes/unreleased/Fixes-20260803-175841.yaml
+++ b/.changes/unreleased/Fixes-20260803-175841.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: environment resource's Delete now treats a 404 (already deleted) as success instead of failing terraform apply
+time: 2026-08-03T17:58:41.056299+03:00

--- a/.changes/unreleased/Fixes-20260804-154217.yaml
+++ b/.changes/unreleased/Fixes-20260804-154217.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: environment resource's Read now treats a 404 (already deleted) as success instead of failing terraform plan/destroy, matching the existing Delete behavior
+time: 2026-08-04T15:42:17.000000+03:00

--- a/pkg/framework/objects/environment/behavior_test.go
+++ b/pkg/framework/objects/environment/behavior_test.go
@@ -1,0 +1,80 @@
+package environment
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestDelete_404IsTreatedAsSuccess is a regression test: Delete used to
+// surface any API error as a hard failure, including a 404 returned when the
+// environment was already gone server-side (e.g. removed via a cascading
+// delete elsewhere), which failed terraform apply even though the resource
+// had, in effect, been deleted.
+func TestDelete_404IsTreatedAsSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected request method %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"status": {"code": 404, "is_success": false, "user_message": "The requested resource was not found. Please check that you have the proper permissions."}}`))
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	client := &dbt_cloud.Client{
+		HostURL:    u,
+		HTTPClient: server.Client(),
+		AccountID:  1,
+		MaxRetries: 1,
+	}
+
+	r := &environmentResource{client: client}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema error: %v", schemaResp.Diagnostics)
+	}
+
+	model := &EnvironmentResourceModel{
+		ID:                      types.StringValue("123:456"),
+		EnvironmentID:           types.Int64Value(456),
+		ProjectID:               types.Int64Value(123),
+		CredentialID:            types.Int64Null(),
+		IsActive:                types.BoolValue(true),
+		Name:                    types.StringValue("test-env"),
+		DbtVersion:              types.StringValue("latest"),
+		Type:                    types.StringValue("deployment"),
+		UseCustomBranch:         types.BoolValue(false),
+		CustomBranch:            types.StringNull(),
+		DeploymentType:          types.StringNull(),
+		ExtendedAttributesID:    types.Int64Null(),
+		ConnectionID:            types.Int64Null(),
+		EnableModelQueryHistory: types.BoolValue(false),
+		PrimaryProfileID:        types.Int64Null(),
+	}
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	if diags := state.Set(context.Background(), model); diags.HasError() {
+		t.Fatalf("failed to build state fixture: %v", diags)
+	}
+
+	resp := &resource.DeleteResponse{State: state}
+	r.Delete(context.Background(), resource.DeleteRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("regression: Delete failed on a 404 instead of treating it as an idempotent success: %v", resp.Diagnostics)
+	}
+}

--- a/pkg/framework/objects/environment/behavior_test.go
+++ b/pkg/framework/objects/environment/behavior_test.go
@@ -78,3 +78,71 @@ func TestDelete_404IsTreatedAsSuccess(t *testing.T) {
 		t.Fatalf("regression: Delete failed on a 404 instead of treating it as an idempotent success: %v", resp.Diagnostics)
 	}
 }
+
+// TestRead_404IsTreatedAsSuccess is a regression test: Read used to surface
+// any API error as a hard failure, including a 404 returned when the
+// environment was already gone server-side. Since terraform destroy (and
+// plan) always refresh state via Read before Delete runs, this hard failure
+// occurred even after Delete was made idempotent to 404s, e.g. when a prior
+// CI/CD delete had actually succeeded server-side but the client timed out
+// and retried.
+func TestRead_404IsTreatedAsSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected request method %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"status": {"code": 404, "is_success": false, "user_message": "The requested resource was not found. Please check that you have the proper permissions."}}`))
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	client := &dbt_cloud.Client{
+		HostURL:    u,
+		HTTPClient: server.Client(),
+		AccountID:  1,
+		MaxRetries: 1,
+	}
+
+	r := &environmentResource{client: client}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema error: %v", schemaResp.Diagnostics)
+	}
+
+	model := &EnvironmentResourceModel{
+		ID:                      types.StringValue("123:456"),
+		EnvironmentID:           types.Int64Value(456),
+		ProjectID:               types.Int64Value(123),
+		CredentialID:            types.Int64Null(),
+		IsActive:                types.BoolValue(true),
+		Name:                    types.StringValue("test-env"),
+		DbtVersion:              types.StringValue("latest"),
+		Type:                    types.StringValue("deployment"),
+		UseCustomBranch:         types.BoolValue(false),
+		CustomBranch:            types.StringNull(),
+		DeploymentType:          types.StringNull(),
+		ExtendedAttributesID:    types.Int64Null(),
+		ConnectionID:            types.Int64Null(),
+		EnableModelQueryHistory: types.BoolValue(false),
+		PrimaryProfileID:        types.Int64Null(),
+	}
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	if diags := state.Set(context.Background(), model); diags.HasError() {
+		t.Fatalf("failed to build state fixture: %v", diags)
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("regression: Read failed on a 404 instead of treating it as an idempotent success: %v", resp.Diagnostics)
+	}
+}

--- a/pkg/framework/objects/environment/resource.go
+++ b/pkg/framework/objects/environment/resource.go
@@ -61,6 +61,9 @@ func (r *environmentResource) Read(
 
 	environment, err := r.client.GetEnvironment(projectID, environmentID)
 	if err != nil {
+		if helper.HandleResourceNotFound(ctx, err, &resp.Diagnostics, &resp.State, "environment") {
+			return
+		}
 		resp.Diagnostics.AddError("Error getting the environment", err.Error())
 		return
 	}

--- a/pkg/framework/objects/environment/resource.go
+++ b/pkg/framework/objects/environment/resource.go
@@ -382,6 +382,10 @@ func (r *environmentResource) Delete(
 		environmentID,
 	)
 	if err != nil {
+		// If the resource is already deleted (404), treat as success
+		if helper.HandleResourceNotFound(ctx, err, &resp.Diagnostics, &resp.State, "environment") {
+			return
+		}
 		resp.Diagnostics.AddError("Error deleting environment", err.Error())
 		return
 	}


### PR DESCRIPTION
## Summary
- `environmentResource.Delete` returned a hard error for any API failure, including a 404 when the environment was already gone server-side (e.g. deleted via cascade from a related resource). That fails `terraform apply`/`destroy` even though the resource is, in effect, already gone.
- Same class of bug already fixed for `notification_setting` (#722): use `helper.HandleResourceNotFound` to treat a 404 as an idempotent success.
- Also fixed the same gap in `Read`: `Read` never called `HandleResourceNotFound` at all, so any 404 there was a hard error too. Since `terraform destroy`/`plan` always refresh state via `Read` before `Delete` runs, this broke destroy for a drifted-away environment even with the `Delete` fix in place (e.g. a CI/CD teardown retry after a prior timed-out request had actually already succeeded server-side).

## How this was found
While investigating acceptance-test flakiness for #723, `TestAccDbtCloudSalesforceCredentialDataSource`'s teardown failed deleting an environment. The logs showed the delete request actually got a real `404` response on its final retry attempt (not a timeout) - the environment had already been removed - but `Delete()` treated that 404 as a hard failure instead of success.

## Verification
Unit tests aside, this was also exercised live against a real dbt Cloud backend (personal devspace) to confirm both the bug and the fix, not just reasoned about from code:
- `terraform apply` created a project + environment; confirmed via direct API call.
- Deleted the environment out-of-band via the API (simulating the CI retry-after-timeout scenario from #723/#724's flakiness report).
- Confirmed `terraform destroy` failed at the refresh (`Read`) step before this fix, even though `Delete` was already idempotent — proving the `Read` gap was real and not just theoretical.
- After patching `Read` the same way, rebuilt and reran: `destroy` succeeded cleanly, and a follow-up API call confirmed the project was actually gone server-side.
- Regression-checked the normal path too: created fresh resources with no drift, ran `apply`/`destroy` end-to-end with no errors.

## Test plan
- [x] Added `TestDelete_404IsTreatedAsSuccess`, confirmed it fails on the pre-fix code and passes on the fix
- [x] Added `TestRead_404IsTreatedAsSuccess`, confirmed it fails on the pre-fix code and passes on the fix
- [x] `go build ./...`
- [x] Live-tested against a real dbt Cloud backend (see Verification above)
