### PR TITLE
fix: project delete fails on legacy invalid dbt_project_subdirectory

### DIFF
--- a/.changes/unreleased/Fixes-20260805-160000.yaml
+++ b/.changes/unreleased/Fixes-20260805-160000.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: project resource's Delete (soft-delete via UpdateProject) no longer validates dbt_project_subdirectory, so legacy projects whose subdirectory predates today's validation rules (e.g. a leading "/") can be destroyed instead of erroring forever
+time: 2026-08-05T16:00:00.000000+03:00

--- a/pkg/dbt_cloud/project.go
+++ b/pkg/dbt_cloud/project.go
@@ -213,7 +213,11 @@ func (c *Client) CreateProject(
 }
 
 func (c *Client) UpdateProject(projectID string, project Project) (*Project, error) {
-	if project.DbtProjectSubdirectory != nil {
+	// Skip subdirectory validation for delete operations (STATE_DELETED): we're not
+	// changing this field, and legacy projects can carry a value (e.g. a leading "/")
+	// that predates today's validation rules, which would otherwise make the project
+	// permanently undeletable via terraform destroy or the API.
+	if project.DbtProjectSubdirectory != nil && project.State != STATE_DELETED {
 		*project.DbtProjectSubdirectory = strings.TrimSpace(*project.DbtProjectSubdirectory)
 		if err := IsValidSubdirectory(*project.DbtProjectSubdirectory); err != nil {
 			return nil, err

--- a/pkg/dbt_cloud/project_test.go
+++ b/pkg/dbt_cloud/project_test.go
@@ -2,6 +2,9 @@ package dbt_cloud_test
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
@@ -182,4 +185,89 @@ func TestIsValidSubdirectory(t *testing.T) {
 			assert.Equal(t, tt.err, err)
 		})
 	}
+}
+
+// newProjectTestClient builds a Client pointed at the given httptest.Server,
+// mirroring the acceptance-test client setup but with retries/timeouts
+// zeroed out so unit tests never block on backoff.
+func newProjectTestClient(t *testing.T, serverURL string) *dbt_cloud.Client {
+	t.Helper()
+
+	accountID := int64(123)
+	token := "test_token"
+	maxRetries := 0
+	retryInterval := 0
+	timeout := 5
+
+	c, err := dbt_cloud.NewClient(
+		&accountID,
+		&token,
+		&serverURL,
+		&maxRetries,
+		&retryInterval,
+		nil,
+		true, // skipCredentialsValidation
+		&timeout,
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+// TestUpdateProject_DeleteSkipsSubdirectoryValidation locks in a fix for a bug
+// where UpdateProject validated DbtProjectSubdirectory even on a soft-delete
+// (State = STATE_DELETED). Since deleting a project never changes that field,
+// a legacy project whose subdirectory predates today's validation rules (e.g.
+// a leading "/") could never be destroyed via terraform destroy or the API -
+// UpdateProject returned a client-side validation error before the request
+// was ever sent. Observed in production against the "Terraform TEST"
+// acceptance-test account: several "Test Project" entries with
+// dbt_project_subdirectory="/dbt" were permanently stuck, e.g.
+//
+//	FAILED to delete project 452153 (Test Project): project subdirectory path should not start with a slash: "/dbt"
+func TestUpdateProject_DeleteSkipsSubdirectoryValidation(t *testing.T) {
+	invalidSubdirectory := "/dbt"
+
+	t.Run("delete with legacy-invalid subdirectory succeeds", func(t *testing.T) {
+		var requests atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{},"status":{"code":200}}`))
+		}))
+		defer srv.Close()
+
+		client := newProjectTestClient(t, srv.URL)
+		project := dbt_cloud.Project{
+			DbtProjectSubdirectory: &invalidSubdirectory,
+			State:                  dbt_cloud.STATE_DELETED,
+		}
+
+		_, err := client.UpdateProject("123", project)
+
+		assert.NoError(t, err)
+		assert.Equal(t, int32(1), requests.Load(), "expected the delete request to actually reach the API")
+	})
+
+	t.Run("non-delete update with the same invalid subdirectory is still rejected", func(t *testing.T) {
+		var requests atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{},"status":{"code":200}}`))
+		}))
+		defer srv.Close()
+
+		client := newProjectTestClient(t, srv.URL)
+		project := dbt_cloud.Project{
+			DbtProjectSubdirectory: &invalidSubdirectory,
+			State:                  0,
+		}
+
+		_, err := client.UpdateProject("123", project)
+
+		assert.Error(t, err)
+		assert.Equal(t, int32(0), requests.Load(), "invalid subdirectory should be rejected client-side before any request is sent")
+	})
 }


### PR DESCRIPTION
## Summary

`UpdateProject` validated `dbt_project_subdirectory` unconditionally, even when the caller is `Delete()` soft-deleting the project (`State = STATE_DELETED`). Delete never changes that field, but if a project's existing subdirectory value predates today's validation rules, `UpdateProject` returns a client-side validation error *before ever sending the request* — permanently blocking that project from being destroyed, via `terraform destroy` or the API.

This mirrors a skip that already existed a few lines below in the same function, for the response-side `ValidateResponse` call on `STATE_DELETED` — the subdirectory check just wasn't included in that skip.

## Real-world evidence

Found while cleaning up ~700 orphaned projects in the shared acceptance-test account. After clearing most of them, a batch of long-lived `"Test Project"` entries consistently failed with the exact same error, unrelated to any timeout or rate limit:

```
FAILED to delete project 452153 (Test Project): project subdirectory path should not start with a slash: "/dbt"
FAILED to delete project 451163 (Test Project): project subdirectory path should not start with a slash: "/dbt"
FAILED to delete project 453254 (Test Project): project subdirectory path should not start with a slash: "/dbt"
... (13 total, all dbt_project_subdirectory="/dbt")
```

These projects were created before the leading-slash validation rule existed, so they've been permanently stuck ever since — no `terraform destroy` or API call could ever clean them up. This is a real customer-facing bug, not just test-account noise: any project with a legacy-invalid subdirectory value is undeletable today.

## Fix

`pkg/dbt_cloud/project.go`: `UpdateProject` now skips the `IsValidSubdirectory` check when `project.State == STATE_DELETED`, matching the existing `ValidateResponse` skip a few lines below.

## Test plan

- Added `TestUpdateProject_DeleteSkipsSubdirectoryValidation` (`pkg/dbt_cloud/project_test.go`), covering:
  - Deleting a project with an invalid (leading-slash) subdirectory now succeeds and the request reaches the API.
  - A non-delete update with the same invalid subdirectory is still rejected client-side (no regression on the existing validation).
- Verified the new test fails against the pre-fix code with the exact same error message seen in production, confirming it reproduces the bug before asserting the fix.