### PR TITLE
[Ad-Hoc] fix ado repo creation

### DIFF
--- a/.changes/unreleased/Fixes-20260806-090217.yaml
+++ b/.changes/unreleased/Fixes-20260806-090217.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: fix ado repo creation scenario
+time: 2026-08-06T09:02:17.275356+03:00

--- a/pkg/dbt_cloud/repository.go
+++ b/pkg/dbt_cloud/repository.go
@@ -190,6 +190,14 @@ func (c *Client) UpdateRepository(
 	// we need to remove the GitLab project ID for updates
 	repository.GitlabProjectID = nil
 
+	// The Azure DevOps fields are create-only (RequiresReplace in the schema) and
+	// are only accepted by the collection-create endpoint. The detail/update
+	// endpoint rejects them as unexpected properties ("Additional properties are
+	// not allowed"), so we strip them from update payloads.
+	repository.AzureActiveDirectoryProjectID = nil
+	repository.AzureActiveDirectoryRepositoryID = nil
+	repository.AzureBypassWebhookRegistrationFailure = nil
+
 	repositoryData, err := json.Marshal(repository)
 	if err != nil {
 		return nil, err

--- a/pkg/dbt_cloud/repository_test.go
+++ b/pkg/dbt_cloud/repository_test.go
@@ -83,3 +83,71 @@ func TestCreateRepository_PreservesRemoteBackendAndFullName(t *testing.T) {
 		t.Errorf("Expected update request to have RepositoryCredentialsID %d, got %d", credentialsID, *updateReq.RepositoryCredentialsID)
 	}
 }
+
+// TestCreateRepository_ADO_StripsAzureFieldsOnUpdate ensures that the Azure
+// DevOps fields, which are create-only (RequiresReplace) and accepted only by
+// the collection-create endpoint, are NOT sent on the follow-up update call.
+// The detail/update endpoint rejects them with a 400 ("Additional properties
+// are not allowed"), so UpdateRepository must strip them.
+func TestCreateRepository_ADO_StripsAzureFieldsOnUpdate(t *testing.T) {
+	const (
+		accountID    = 123
+		projectID    = 456
+		repositoryID = 789
+	)
+
+	server := testutil.NewMockRepositoryServer(accountID, projectID, repositoryID)
+	defer server.Close()
+
+	backend := "ado"
+	azureProjectID := "12345678-1234-1234-1234-1234567890ab"
+	azureRepositoryID := "87654321-4321-abcd-abcd-464327678642"
+	bypass := false
+
+	adoResponse := &dbt_cloud.RepositoryResponse{
+		Data: dbt_cloud.Repository{
+			ID:                                    testutil.IntPtr(repositoryID),
+			RemoteBackend:                         &backend,
+			AzureActiveDirectoryProjectID:         &azureProjectID,
+			AzureActiveDirectoryRepositoryID:      &azureRepositoryID,
+			AzureBypassWebhookRegistrationFailure: &bypass,
+		},
+	}
+	server.SetCreateResponse(adoResponse)
+	server.SetUpdateResponse(adoResponse)
+
+	client := testutil.CreateTestClient(server.URL(), accountID)
+
+	// A pull_request_url_template forces the follow-up UpdateRepository call.
+	_, err := client.CreateRepository(
+		projectID,
+		"https://abc@dev.azure.com/abc/def/_git/my_repo",
+		true,
+		"azure_active_directory_app",
+		0,
+		0,
+		"",
+		azureProjectID,
+		azureRepositoryID,
+		bypass,
+		"https://dev.azure.com/abc/def/pullrequestcreate?sourceRef={{source}}&targetRef={{destination}}",
+	)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	updateReq := server.GetLastUpdateRequest()
+	if updateReq == nil {
+		t.Fatal("Expected update request to be made")
+	}
+
+	if updateReq.AzureActiveDirectoryProjectID != nil {
+		t.Errorf("Expected AzureActiveDirectoryProjectID to be stripped from update, got '%v'", *updateReq.AzureActiveDirectoryProjectID)
+	}
+	if updateReq.AzureActiveDirectoryRepositoryID != nil {
+		t.Errorf("Expected AzureActiveDirectoryRepositoryID to be stripped from update, got '%v'", *updateReq.AzureActiveDirectoryRepositoryID)
+	}
+	if updateReq.AzureBypassWebhookRegistrationFailure != nil {
+		t.Errorf("Expected AzureBypassWebhookRegistrationFailure to be stripped from update, got '%v'", *updateReq.AzureBypassWebhookRegistrationFailure)
+	}
+}


### PR DESCRIPTION
Problem: Creating a `dbtcloud_repository` for ADO fails with 400.

Cause: The API doesn't accept ADO fields on update, only create. Even if the operation is Create, the provider also calls Update when `pull_request_url_template` is set. Error below.
`Additional properties are not allowed ('azure_active_directory_project_id', 'azure_active_directory_repository_id', 'azure_bypass_webhook_registration_failure' were unexpected)`

Solution: Since they are marked as RequireReplace anyway, we reset them to `nil` before marshaling, similar to the GitlabProjectID stopgap.