### PR TITLE
Delete dead Adapter code

### DIFF
--- a/.changes/unreleased/Changes-20260812-132149.yaml
+++ b/.changes/unreleased/Changes-20260812-132149.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: Remove dead code
+time: 2026-08-12T13:21:49.50805+02:00

--- a/pkg/dbt_cloud/adapter.go
+++ b/pkg/dbt_cloud/adapter.go
@@ -1,29 +1,5 @@
 package dbt_cloud
 
-type Adapter struct {
-	ID                      *int            `json:"id,omitempty"`
-	AccountID               int64           `json:"account_id"`
-	ProjectID               int             `json:"project_id"`
-	CreatedByID             *int            `json:"created_by_id,omitempty"`
-	CreatedByServiceTokenID *int            `json:"created_by_service_token_id,omitempty"`
-	Metadata                AdapterMetadata `json:"metadata_json"`
-	State                   int             `json:"state"`
-	AdapterVersion          string          `json:"adapter_version"`
-	CreatedAt               *string         `json:"created_at,omitempty"`
-	UpdatedAt               *string         `json:"updated_at,omitempty"`
-}
-
-type AdapterMetadata struct {
-	Title     string `json:"title"`
-	DocsLink  string `json:"docs_link"`
-	ImageLink string `json:"image_link"`
-}
-
-type AdapterResponse struct {
-	Data   Adapter        `json:"data"`
-	Status ResponseStatus `json:"status"`
-}
-
 type AdapterCredentialFieldMetadataValidation struct {
 	Required bool `json:"required"`
 }


### PR DESCRIPTION
Cloud Config has deprecated the separate `dbt_adapter` resource long ago. The terraform provider hasn't made use of it for some time, remove the typedefs as well.