### PR TITLE
fix: honor write-only semantic layer credential secrets

### DIFF
--- a/.changes/unreleased/Fixes-20260823-225816.yaml
+++ b/.changes/unreleased/Fixes-20260823-225816.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: 'Send write-only secrets when creating or updating semantic layer credentials'
+time: 2026-08-23T22:58:16.1508412+08:00

--- a/pkg/framework/objects/semantic_layer_credential/databricks_sl_credential_resource.go
+++ b/pkg/framework/objects/semantic_layer_credential/databricks_sl_credential_resource.go
@@ -66,16 +66,22 @@ func (r *databricksSemanticLayerCredentialResource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan DatabricksSLCredentialModel
+	var plan, config DatabricksSLCredentialModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	token := helper.ResolveWriteOnlyString(config.Credential.TokenWo, plan.Credential.Token)
 
 	values := map[string]interface{}{
 		"catalog": plan.Credential.Catalog.ValueString(),
-		"token":   plan.Credential.Token.ValueString(),
+		"token":   token,
 	}
 
 	createdCredential, err := r.client.CreateSemanticLayerCredential(
@@ -130,9 +136,13 @@ func (r *databricksSemanticLayerCredentialResource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan, state DatabricksSLCredentialModel
+	var plan, state, config DatabricksSLCredentialModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -152,9 +162,10 @@ func (r *databricksSemanticLayerCredentialResource) Update(
 		return
 	}
 
+	token := helper.ResolveWriteOnlyString(config.Credential.TokenWo, plan.Credential.Token)
 	values := map[string]interface{}{
 		"catalog": plan.Credential.Catalog.ValueString(),
-		"token":   plan.Credential.Token.ValueString(),
+		"token":   token,
 	}
 
 	credential.Values = values
@@ -173,14 +184,10 @@ func (r *databricksSemanticLayerCredentialResource) Update(
 	}
 
 	state.ID = types.Int64Value(int64(*credential.ID))
+	state.Configuration = plan.Configuration
+	state.Credential = plan.Credential
 	state.Credential.CredentialID = types.Int64Value(int64(*credential.ID))
-
-	//update config fields
-	state.Configuration.Name = types.StringValue(credential.Name)
-
-	//update credential fields
-	state.Credential.Catalog = types.StringValue(credential.Values["catalog"].(string))
-	state.Credential.Token = types.StringValue(credential.Values["token"].(string))
+	state.Credential.ID = types.StringValue(fmt.Sprintf("%d", *credential.ID))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/pkg/framework/objects/semantic_layer_credential/postgres_sl_credential_resource.go
+++ b/pkg/framework/objects/semantic_layer_credential/postgres_sl_credential_resource.go
@@ -68,18 +68,19 @@ func (r *postgresSemanticLayerCredentialResource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan PostgresSLCredentialModel
+	var plan, config PostgresSLCredentialModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	projectID := plan.Credential.ProjectID.ValueInt64()
-	password := ""
-	if plan.Credential.Password.ValueStringPointer() != nil {
-		password = *plan.Credential.Password.ValueStringPointer()
-	}
+	password := helper.ResolveWriteOnlyString(config.Credential.PasswordWo, plan.Credential.Password)
 
 	values := map[string]interface{}{
 		"username": plan.Credential.Username.ValueString(),
@@ -140,10 +141,14 @@ func (r *postgresSemanticLayerCredentialResource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan, state PostgresSLCredentialModel
+	var plan, state, config PostgresSLCredentialModel
 
 	// Read plan and state values into the models
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -165,9 +170,10 @@ func (r *postgresSemanticLayerCredentialResource) Update(
 	}
 
 	//add credential fields to values map
+	password := helper.ResolveWriteOnlyString(config.Credential.PasswordWo, plan.Credential.Password)
 	values := map[string]interface{}{
 		"username": plan.Credential.Username.ValueString(),
-		"password": plan.Credential.Password.ValueString(),
+		"password": password,
 	}
 
 	credential.Name = plan.Configuration.Name.ValueString()
@@ -187,14 +193,10 @@ func (r *postgresSemanticLayerCredentialResource) Update(
 	}
 
 	state.ID = types.Int64Value(int64(*credential.ID))
+	state.Configuration = plan.Configuration
+	state.Credential = plan.Credential
 	state.Credential.CredentialID = types.Int64Value(int64(*credential.ID))
-
-	//update config fields
-	state.Configuration.Name = types.StringValue(credential.Name)
-
-	//update credential fields
-	state.Credential.Password = getStringFromMap(credential.Values, "password")
-	state.Credential.Username = getStringFromMap(credential.Values, "username")
+	state.Credential.ID = types.StringValue(fmt.Sprintf("%d", *credential.ID))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/pkg/framework/objects/semantic_layer_credential/redshift_sl_credential_resource.go
+++ b/pkg/framework/objects/semantic_layer_credential/redshift_sl_credential_resource.go
@@ -68,18 +68,19 @@ func (r *redshiftSemanticLayerCredentialResource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan RedshiftSLCredentialModel
+	var plan, config RedshiftSLCredentialModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	projectID := plan.Credential.ProjectID.ValueInt64()
-	password := ""
-	if plan.Credential.Password.ValueStringPointer() != nil {
-		password = *plan.Credential.Password.ValueStringPointer()
-	}
+	password := helper.ResolveWriteOnlyString(config.Credential.PasswordWo, plan.Credential.Password)
 
 	values := map[string]interface{}{
 		"username": plan.Credential.Username.ValueString(),
@@ -140,10 +141,14 @@ func (r *redshiftSemanticLayerCredentialResource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan, state RedshiftSLCredentialModel
+	var plan, state, config RedshiftSLCredentialModel
 
 	// Read plan and state values into the models
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -165,9 +170,10 @@ func (r *redshiftSemanticLayerCredentialResource) Update(
 	}
 
 	//add credential fields to values map
+	password := helper.ResolveWriteOnlyString(config.Credential.PasswordWo, plan.Credential.Password)
 	values := map[string]interface{}{
 		"username": plan.Credential.Username.ValueString(),
-		"password": plan.Credential.Password.ValueString(),
+		"password": password,
 	}
 
 	credential.Name = plan.Configuration.Name.ValueString()
@@ -187,14 +193,10 @@ func (r *redshiftSemanticLayerCredentialResource) Update(
 	}
 
 	state.ID = types.Int64Value(int64(*credential.ID))
+	state.Configuration = plan.Configuration
+	state.Credential = plan.Credential
 	state.Credential.CredentialID = types.Int64Value(int64(*credential.ID))
-
-	//update config fields
-	state.Configuration.Name = types.StringValue(credential.Name)
-
-	//update credential fields
-	state.Credential.Password = getStringFromMap(credential.Values, "password")
-	state.Credential.Username = getStringFromMap(credential.Values, "username")
+	state.Credential.ID = types.StringValue(fmt.Sprintf("%d", *credential.ID))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/pkg/framework/objects/semantic_layer_credential/snowflake_sl_credential_resource.go
+++ b/pkg/framework/objects/semantic_layer_credential/snowflake_sl_credential_resource.go
@@ -68,22 +68,29 @@ func (r *snowflakeSemanticLayerCredentialResource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan SnowflakeSLCredentialModel
+	var plan, config SnowflakeSLCredentialModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	projectID := plan.Credential.ProjectID.ValueInt64()
+	password := helper.ResolveWriteOnlyString(config.Credential.PasswordWo, plan.Credential.Password)
+	privateKey := helper.ResolveWriteOnlyString(config.Credential.PrivateKeyWo, plan.Credential.PrivateKey)
+	privateKeyPassphrase := helper.ResolveWriteOnlyString(config.Credential.PrivateKeyPassphraseWo, plan.Credential.PrivateKeyPassphrase)
 
 	values := map[string]interface{}{
 		"role":                   plan.Credential.Role.ValueString(),
 		"warehouse":              plan.Credential.Warehouse.ValueString(),
 		"user":                   plan.Credential.User.ValueString(),
-		"password":               plan.Credential.Password.ValueString(),
-		"private_key":            plan.Credential.PrivateKey.ValueString(),
-		"private_key_passphrase": plan.Credential.PrivateKeyPassphrase.ValueString(),
+		"password":               password,
+		"private_key":            privateKey,
+		"private_key_passphrase": privateKeyPassphrase,
 		"auth_type":              plan.Credential.AuthType.ValueString(),
 	}
 
@@ -144,10 +151,14 @@ func (r *snowflakeSemanticLayerCredentialResource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan, state SnowflakeSLCredentialModel
+	var plan, state, config SnowflakeSLCredentialModel
 
 	// Read plan and state values into the models
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -168,13 +179,17 @@ func (r *snowflakeSemanticLayerCredentialResource) Update(
 		return
 	}
 
+	password := helper.ResolveWriteOnlyString(config.Credential.PasswordWo, plan.Credential.Password)
+	privateKey := helper.ResolveWriteOnlyString(config.Credential.PrivateKeyWo, plan.Credential.PrivateKey)
+	privateKeyPassphrase := helper.ResolveWriteOnlyString(config.Credential.PrivateKeyPassphraseWo, plan.Credential.PrivateKeyPassphrase)
+
 	values := map[string]interface{}{
 		"role":                   plan.Credential.Role.ValueString(),
 		"warehouse":              plan.Credential.Warehouse.ValueString(),
 		"user":                   plan.Credential.User.ValueString(),
-		"password":               plan.Credential.Password.ValueString(),
-		"private_key":            plan.Credential.PrivateKey.ValueString(),
-		"private_key_passphrase": plan.Credential.PrivateKeyPassphrase.ValueString(),
+		"password":               password,
+		"private_key":            privateKey,
+		"private_key_passphrase": privateKeyPassphrase,
 		"auth_type":              plan.Credential.AuthType.ValueString(),
 	}
 
@@ -194,19 +209,10 @@ func (r *snowflakeSemanticLayerCredentialResource) Update(
 	}
 
 	state.ID = types.Int64Value(int64(*credential.ID))
+	state.Configuration = plan.Configuration
+	state.Credential = plan.Credential
 	state.Credential.CredentialID = types.Int64Value(int64(*credential.ID))
-
-	//update config fields
-	state.Configuration.Name = types.StringValue(credential.Name)
-
-	//update credential fields
-	state.Credential.AuthType = types.StringValue(credential.Values["auth_type"].(string))
-	state.Credential.Role = types.StringValue(credential.Values["role"].(string))
-	state.Credential.Warehouse = types.StringValue(credential.Values["warehouse"].(string))
-	state.Credential.Password = types.StringValue(credential.Values["password"].(string))
-	state.Credential.User = types.StringValue(credential.Values["user"].(string))
-	state.Credential.PrivateKey = types.StringValue(credential.Values["private_key"].(string))
-	state.Credential.PrivateKeyPassphrase = types.StringValue(credential.Values["private_key_passphrase"].(string))
+	state.Credential.ID = types.StringValue(fmt.Sprintf("%d", *credential.ID))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/pkg/framework/objects/semantic_layer_credential/write_only_secrets_unit_test.go
+++ b/pkg/framework/objects/semantic_layer_credential/write_only_secrets_unit_test.go
@@ -1,0 +1,267 @@
+package semantic_layer_credential_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/acctest_helper"
+	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/testhelpers"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestSemanticLayerCredentials_WriteOnlySecrets(t *testing.T) {
+	testCases := []struct {
+		name           string
+		resource       string
+		adapterVersion string
+		readValues     map[string]interface{}
+		createSecrets  map[string]string
+		updateSecrets  map[string]string
+		writeOnlyAttrs []string
+		config         func(string, int) string
+	}{
+		{
+			name:           "snowflake keypair",
+			resource:       "dbtcloud_snowflake_semantic_layer_credential.test",
+			adapterVersion: "snowflake_v0",
+			readValues: map[string]interface{}{
+				"auth_type": "keypair",
+				"role":      "test-role",
+				"warehouse": "test-warehouse",
+			},
+			createSecrets: map[string]string{
+				"private_key":            "create-private-key",
+				"private_key_passphrase": "create-passphrase",
+			},
+			updateSecrets: map[string]string{
+				"private_key":            "update-private-key",
+				"private_key_passphrase": "update-passphrase",
+			},
+			writeOnlyAttrs: []string{"credential.private_key_wo", "credential.private_key_passphrase_wo"},
+			config:         snowflakeWriteOnlyConfig,
+		},
+		{
+			name:           "redshift password",
+			resource:       "dbtcloud_redshift_semantic_layer_credential.test",
+			adapterVersion: "redshift_v0",
+			readValues:     map[string]interface{}{"username": "test-user"},
+			createSecrets:  map[string]string{"password": "create-password"},
+			updateSecrets:  map[string]string{"password": "update-password"},
+			writeOnlyAttrs: []string{"credential.password_wo"},
+			config:         redshiftWriteOnlyConfig,
+		},
+		{
+			name:           "postgres password",
+			resource:       "dbtcloud_postgres_semantic_layer_credential.test",
+			adapterVersion: "postgres_v0",
+			readValues:     map[string]interface{}{"username": "test-user"},
+			createSecrets:  map[string]string{"password": "create-password"},
+			updateSecrets:  map[string]string{"password": "update-password"},
+			writeOnlyAttrs: []string{"credential.password_wo"},
+			config:         postgresWriteOnlyConfig,
+		},
+		{
+			name:           "databricks token",
+			resource:       "dbtcloud_databricks_semantic_layer_credential.test",
+			adapterVersion: "databricks_v0",
+			readValues:     map[string]interface{}{"catalog": "test-catalog"},
+			createSecrets:  map[string]string{"token": "create-token"},
+			updateSecrets:  map[string]string{"token": "update-token"},
+			writeOnlyAttrs: []string{"credential.token_wo"},
+			config:         databricksWriteOnlyConfig,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("TF_ACC", "1")
+
+			const credentialID = 42
+			createPath := "/v3/accounts/1/semantic-layer-credentials/"
+			credentialPath := fmt.Sprintf("/v3/accounts/1/semantic-layer-credentials/%d", credentialID)
+			updatePath := credentialPath + "/"
+
+			response := map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":              credentialID,
+					"account_id":      1,
+					"project_id":      123,
+					"name":            "test-credential",
+					"adapter_version": testCase.adapterVersion,
+					"schema_type":     "semantic_layer_credentials",
+					"values":          testCase.readValues,
+				},
+				"status": map[string]interface{}{
+					"code":       200,
+					"is_success": true,
+				},
+			}
+
+			updateCalls := 0
+			handlers := map[string]testhelpers.MockEndpointHandler{
+				"POST " + createPath: func(r *http.Request) (int, interface{}, error) {
+					if err := requestContainsSecrets(r, testCase.createSecrets); err != nil {
+						return http.StatusBadRequest, nil, err
+					}
+					return http.StatusOK, response, nil
+				},
+				"GET " + credentialPath: func(_ *http.Request) (int, interface{}, error) {
+					return http.StatusOK, response, nil
+				},
+				"POST " + updatePath: func(r *http.Request) (int, interface{}, error) {
+					if err := requestContainsSecrets(r, testCase.updateSecrets); err != nil {
+						return http.StatusBadRequest, nil, err
+					}
+					updateCalls++
+					return http.StatusOK, response, nil
+				},
+				"DELETE " + updatePath: func(_ *http.Request) (int, interface{}, error) {
+					return http.StatusOK, response, nil
+				},
+			}
+
+			server := testhelpers.SetupMockServer(t, handlers)
+			defer server.Close()
+
+			providerConfig := fmt.Sprintf(`
+provider "dbtcloud" {
+  host_url   = %q
+  token      = "test-token"
+  account_id = 1
+}
+`, server.URL)
+			createChecks := writeOnlyStateChecks(testCase.resource, testCase.writeOnlyAttrs, "1")
+			updateChecks := writeOnlyStateChecks(testCase.resource, testCase.writeOnlyAttrs, "2")
+
+			resource.Test(t, resource.TestCase{
+				IsUnitTest:               true,
+				ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: providerConfig + testCase.config("create", 1),
+						Check:  resource.ComposeTestCheckFunc(createChecks...),
+					},
+					{
+						Config: providerConfig + testCase.config("update", 2),
+						Check:  resource.ComposeTestCheckFunc(updateChecks...),
+					},
+				},
+			})
+
+			if updateCalls != 1 {
+				t.Fatalf("expected one update request, got %d", updateCalls)
+			}
+		})
+	}
+}
+
+func requestContainsSecrets(r *http.Request, expected map[string]string) error {
+	var body struct {
+		Values map[string]interface{} `json:"values"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return fmt.Errorf("decode request: %w", err)
+	}
+	for key, expectedValue := range expected {
+		if body.Values[key] != expectedValue {
+			return fmt.Errorf("request did not contain the configured %s", key)
+		}
+	}
+	return nil
+}
+
+func writeOnlyStateChecks(resourceName string, attributes []string, version string) []resource.TestCheckFunc {
+	checks := make([]resource.TestCheckFunc, 0, len(attributes)*2)
+	for _, attribute := range attributes {
+		checks = append(checks,
+			resource.TestCheckNoResourceAttr(resourceName, attribute),
+			resource.TestCheckResourceAttr(resourceName, attribute+"_version", version),
+		)
+	}
+	return checks
+}
+
+func snowflakeWriteOnlyConfig(prefix string, version int) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_snowflake_semantic_layer_credential" "test" {
+  configuration = {
+    project_id      = 123
+    name            = "test-credential"
+    adapter_version = "snowflake_v0"
+  }
+  credential = {
+    project_id                        = 123
+    is_active                        = true
+    auth_type                        = "keypair"
+    role                             = "test-role"
+    warehouse                        = "test-warehouse"
+    private_key_wo                   = "%s-private-key"
+    private_key_wo_version           = %d
+    private_key_passphrase_wo         = "%s-passphrase"
+    private_key_passphrase_wo_version = %d
+    num_threads                       = 3
+    semantic_layer_credential         = true
+  }
+}
+`, prefix, version, prefix, version)
+}
+
+func redshiftWriteOnlyConfig(prefix string, version int) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_redshift_semantic_layer_credential" "test" {
+  configuration = {
+    project_id      = 123
+    name            = "test-credential"
+    adapter_version = "redshift_v0"
+  }
+  credential = {
+    project_id          = 123
+    username            = "test-user"
+    password_wo         = "%s-password"
+    password_wo_version = %d
+    default_schema      = "test_schema"
+    num_threads         = 3
+  }
+}
+`, prefix, version)
+}
+
+func postgresWriteOnlyConfig(prefix string, version int) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_postgres_semantic_layer_credential" "test" {
+  configuration = {
+    project_id      = 123
+    name            = "test-credential"
+    adapter_version = "postgres_v0"
+  }
+  credential = {
+    project_id                = 123
+    username                  = "test-user"
+    password_wo               = "%s-password"
+    password_wo_version       = %d
+    semantic_layer_credential = true
+  }
+}
+`, prefix, version)
+}
+
+func databricksWriteOnlyConfig(prefix string, version int) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_databricks_semantic_layer_credential" "test" {
+  configuration = {
+    project_id      = 123
+    name            = "test-credential"
+    adapter_version = "databricks_v0"
+  }
+  credential = {
+    project_id                = 123
+    catalog                   = "test-catalog"
+    token_wo                  = "%s-token"
+    token_wo_version          = %d
+    semantic_layer_credential = true
+  }
+}
+`, prefix, version)
+}


### PR DESCRIPTION
Fixes #732.

The nested Snowflake, Redshift, Postgres, and Databricks semantic-layer credential resources read write-only secrets from the plan, where those values are unavailable. This change resolves write-only and regular inputs from configuration and plan, and keeps secret values out of update state.

Tests:
- `go test -p 1 -mod=readonly -count=1 ./...`
- `go build -p 1 -mod=readonly -ldflags "-w -s" .`
- `go vet ./pkg/framework/objects/semantic_layer_credential`
- `go generate ./...` and `git diff --exit-code -- docs`

Not run locally: `make test-acceptance` (requires private dbt Cloud and warehouse credentials).