### PR TITLE
bugfixes for bq wif

### DIFF
--- a/.changes/unreleased/Fixes-20260902-135638.yaml
+++ b/.changes/unreleased/Fixes-20260902-135638.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: ' Fix issues with BQ WIF'
+time: 2026-09-02T13:56:38.85713+03:00

--- a/docs/data-sources/bigquery_credential.md
+++ b/docs/data-sources/bigquery_credential.md
@@ -22,7 +22,10 @@ Bigquery credential data source
 
 ### Read-Only
 
+- `auth_type` (String) The authentication method for the BigQuery credential
 - `dataset` (String) Default dataset name
 - `id` (String) The ID of this data source. Contains the project ID and the credential ID.
 - `is_active` (Boolean) Whether the BigQuery credential is active
 - `num_threads` (Number) Number of threads to use
+- `service_account_impersonation_url` (String) The URL for the service account impersonation request
+- `workload_pool_provider_path` (String) The fully specified resource name of the workload pool provider

--- a/docs/data-sources/global_connection.md
+++ b/docs/data-sources/global_connection.md
@@ -103,6 +103,7 @@ Read-Only:
 - `gcs_bucket` (String) URI for a Google Cloud Storage bucket to host Python code executed via Datapro
 - `impersonate_service_account` (String) Service Account to impersonate when running queries
 - `job_creation_timeout_seconds` (Number) Maximum timeout for the job creation step
+- `job_execution_timeout_seconds` (Number) Timeout in seconds for job execution, used by the bigquery_v1 adapter
 - `job_retry_deadline_seconds` (Number) Total number of seconds to wait while retrying the same query
 - `location` (String) Location to create new Datasets in
 - `maximum_bytes_billed` (Number) Max number of bytes that can be billed for a given BigQuery query
@@ -113,6 +114,7 @@ Read-Only:
 - `scopes` (Set of String) OAuth scopes for the BigQuery connection
 - `timeout_seconds` (Number) Timeout in seconds for queries
 - `token_uri` (String) Token URI for the Service Account
+- `use_latest_adapter` (Boolean) Whether the connection uses the latest bigquery_v1 adapter (used for BQ WIF)
 
 
 <a id="nestedatt--databricks"></a>

--- a/docs/resources/bigquery_credential.md
+++ b/docs/resources/bigquery_credential.md
@@ -40,8 +40,11 @@ resource "dbtcloud_bigquery_credential" "my_credential_v1" {
 
 ### Optional
 
+- `auth_type` (String) The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
 - `connection_id` (Number) The ID of the global connection to use for this credential. When provided, the credential will automatically use the correct adapter version based on the connection's configuration (e.g., bigquery_v1 for connections with use_latest_adapter=true).
 - `is_active` (Boolean) Whether the BigQuery credential is active
+- `service_account_impersonation_url` (String) The URL for the service account impersonation request, used when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
+- `workload_pool_provider_path` (String) The fully specified resource name of the workload pool provider, required when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
 
 ### Read-Only
 

--- a/docs/resources/bigquery_semantic_layer_credential.md
+++ b/docs/resources/bigquery_semantic_layer_credential.md
@@ -84,8 +84,11 @@ Required:
 
 Optional:
 
+- `auth_type` (String) The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
 - `connection_id` (Number) The ID of the global connection to use for this credential. When provided, the credential will automatically use the correct adapter version based on the connection's configuration (e.g., bigquery_v1 for connections with use_latest_adapter=true).
 - `is_active` (Boolean) Whether the BigQuery credential is active
+- `service_account_impersonation_url` (String) The URL for the service account impersonation request, used when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
+- `workload_pool_provider_path` (String) The fully specified resource name of the workload pool provider, required when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
 
 Read-Only:
 

--- a/docs/resources/bigquery_semantic_layer_credential.md
+++ b/docs/resources/bigquery_semantic_layer_credential.md
@@ -84,11 +84,8 @@ Required:
 
 Optional:
 
-- `auth_type` (String) The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
 - `connection_id` (Number) The ID of the global connection to use for this credential. When provided, the credential will automatically use the correct adapter version based on the connection's configuration (e.g., bigquery_v1 for connections with use_latest_adapter=true).
 - `is_active` (Boolean) Whether the BigQuery credential is active
-- `service_account_impersonation_url` (String) The URL for the service account impersonation request, used when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
-- `workload_pool_provider_path` (String) The fully specified resource name of the workload pool provider, required when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).
 
 Read-Only:
 

--- a/docs/resources/global_connection.md
+++ b/docs/resources/global_connection.md
@@ -190,7 +190,7 @@ resource "dbtcloud_global_connection" "teradata" {
 - `bigquery` (Attributes) (see [below for nested schema](#nestedatt--bigquery))
 - `databricks` (Attributes) Databricks connection configuration (see [below for nested schema](#nestedatt--databricks))
 - `fabric` (Attributes) Microsoft Fabric connection configuration. (see [below for nested schema](#nestedatt--fabric))
-- `oauth_configuration_id` (Number) External OAuth configuration ID (only Snowflake for now)
+- `oauth_configuration_id` (Number) External OAuth configuration ID. Supported for all connection types.
 - `postgres` (Attributes) PostgreSQL connection configuration. (see [below for nested schema](#nestedatt--postgres))
 - `private_link_endpoint_id` (String) Private Link Endpoint ID. This ID can be found using the `privatelink_endpoint` data source
 - `redshift` (Attributes) Redshift connection configuration (see [below for nested schema](#nestedatt--redshift))

--- a/pkg/dbt_cloud/bigquery_credential.go
+++ b/pkg/dbt_cloud/bigquery_credential.go
@@ -14,8 +14,11 @@ type BigQueryCredentialResponse struct {
 
 // BigQueryUnencryptedCredentialDetails contains the readable credential values for v1 credentials
 type BigQueryUnencryptedCredentialDetails struct {
-	Schema  string `json:"schema"`
-	Threads int    `json:"threads"`
+	Schema                         string `json:"schema"`
+	Threads                        int    `json:"threads"`
+	AuthType                       string `json:"auth_type,omitempty"`
+	WorkloadPoolProviderPath       string `json:"workload_pool_provider_path,omitempty"`
+	ServiceAccountImpersonationURL string `json:"service_account_impersonation_url,omitempty"`
 }
 
 type BigQueryCredential struct {
@@ -49,6 +52,30 @@ func (c *BigQueryCredential) GetThreads() int {
 	}
 	// For v0 credentials or if not found
 	return c.Threads
+}
+
+// GetAuthType returns the auth_type from unencrypted_credential_details (v1 only)
+func (c *BigQueryCredential) GetAuthType() string {
+	if c.UnencryptedCredentialDetails != nil {
+		return c.UnencryptedCredentialDetails.AuthType
+	}
+	return ""
+}
+
+// GetWorkloadPoolProviderPath returns the workload_pool_provider_path from unencrypted_credential_details (v1 only)
+func (c *BigQueryCredential) GetWorkloadPoolProviderPath() string {
+	if c.UnencryptedCredentialDetails != nil {
+		return c.UnencryptedCredentialDetails.WorkloadPoolProviderPath
+	}
+	return ""
+}
+
+// GetServiceAccountImpersonationURL returns the service_account_impersonation_url from unencrypted_credential_details (v1 only)
+func (c *BigQueryCredential) GetServiceAccountImpersonationURL() string {
+	if c.UnencryptedCredentialDetails != nil {
+		return c.UnencryptedCredentialDetails.ServiceAccountImpersonationURL
+	}
+	return ""
 }
 
 // BigQueryCredentialGlobConn is used for creating credentials with the new adapter format (bigquery_v1)
@@ -103,6 +130,9 @@ func (c *Client) CreateBigQueryCredential(
 	dataset string,
 	numThreads int,
 	adapterVersion string,
+	authType string,
+	workloadPoolProviderPath string,
+	serviceAccountImpersonationURL string,
 ) (*BigQueryCredential, error) {
 	var requestData []byte
 	var err error
@@ -110,7 +140,7 @@ func (c *Client) CreateBigQueryCredential(
 	// When adapter_version is provided, use the new adapter format with credential_details
 	// This is required for connections using use_latest_adapter=true (bigquery_v1)
 	if adapterVersion != "" {
-		credentialDetails, err := GenerateBigQueryCredentialDetails(dataset, numThreads)
+		credentialDetails, err := GenerateBigQueryCredentialDetails(dataset, numThreads, authType, workloadPoolProviderPath, serviceAccountImpersonationURL)
 		if err != nil {
 			return nil, err
 		}
@@ -173,62 +203,85 @@ func (c *Client) CreateBigQueryCredential(
 }
 
 // GenerateBigQueryCredentialDetails creates the credential_details structure for BigQuery v1 credentials
-func GenerateBigQueryCredentialDetails(dataset string, numThreads int) (AdapterCredentialDetails, error) {
+func GenerateBigQueryCredentialDetails(
+	dataset string,
+	numThreads int,
+	authType string,
+	workloadPoolProviderPath string,
+	serviceAccountImpersonationURL string,
+) (AdapterCredentialDetails, error) {
 	// The credential_details structure for BigQuery follows the same pattern as other adapters
-	defaultConfig := `{
-	"fields": {
+	fields := map[string]AdapterCredentialField{
 		"schema": {
-			"metadata": {
-				"label": "Dataset",
-				"description": "The default dataset to use for this credential",
-				"field_type": "text",
-				"encrypt": false,
-				"overrideable": false,
-				"validation": {
-					"required": true
-				}
+			Metadata: AdapterCredentialFieldMetadata{
+				Label:       "Dataset",
+				Description: "The default dataset to use for this credential",
+				Field_Type:  "text",
+				Encrypt:     false,
+				Validation:  AdapterCredentialFieldMetadataValidation{Required: true},
 			},
-			"value": ""
+			Value: dataset,
 		},
 		"threads": {
-			"metadata": {
-				"label": "Threads",
-				"description": "The number of threads to use",
-				"field_type": "number",
-				"encrypt": false,
-				"overrideable": false,
-				"validation": {
-					"required": true
-				}
+			Metadata: AdapterCredentialFieldMetadata{
+				Label:       "Threads",
+				Description: "The number of threads to use",
+				Field_Type:  "number",
+				Encrypt:     false,
+				Validation:  AdapterCredentialFieldMetadataValidation{Required: true},
 			},
-			"value": 4
+			Value: numThreads,
+		},
+	}
+
+	if authType != "" {
+		fields["auth_type"] = AdapterCredentialField{
+			Metadata: AdapterCredentialFieldMetadata{
+				Label:       "Authentication Method",
+				Description: "The authentication method to use for this credential.",
+				Field_Type:  "select",
+				Encrypt:     false,
+				Validation:  AdapterCredentialFieldMetadataValidation{Required: true},
+				Options: []AdapterCredentialFieldMetadataOptions{
+					{Label: "Service Account JSON", Value: "service-account-json"},
+					{Label: "Native OAuth", Value: "oauth-secrets"},
+					{Label: "Workload Identity Federation", Value: "external-oauth-wif"},
+				},
+			},
+			Value: authType,
 		}
 	}
-}`
 
-	var bigQueryCredentialDetailsDefault AdapterCredentialDetails
-	err := json.Unmarshal([]byte(defaultConfig), &bigQueryCredentialDetailsDefault)
-	if err != nil {
-		return bigQueryCredentialDetailsDefault, err
+	if workloadPoolProviderPath != "" {
+		fields["workload_pool_provider_path"] = AdapterCredentialField{
+			Metadata: AdapterCredentialFieldMetadata{
+				Label:       "Workload Pool Provider Path",
+				Description: "The fully specified resource name of the workload pool provider",
+				Field_Type:  "text",
+				Encrypt:     false,
+				Validation:  AdapterCredentialFieldMetadataValidation{Required: true},
+			},
+			Value: workloadPoolProviderPath,
+		}
 	}
 
-	fieldMapping := map[string]interface{}{
-		"schema":  dataset,
-		"threads": numThreads,
+	if serviceAccountImpersonationURL != "" {
+		fields["service_account_impersonation_url"] = AdapterCredentialField{
+			Metadata: AdapterCredentialFieldMetadata{
+				Label:       "Service Account Impersonation URL",
+				Description: "The URL for the service account impersonation request",
+				Field_Type:  "text",
+				Encrypt:     false,
+				Validation:  AdapterCredentialFieldMetadataValidation{Required: false},
+			},
+			Value: serviceAccountImpersonationURL,
+		}
 	}
 
-	bigQueryCredentialFields := map[string]AdapterCredentialField{}
-	for key, value := range bigQueryCredentialDetailsDefault.Fields {
-		field := value
-		field.Value = fieldMapping[key]
-		bigQueryCredentialFields[key] = field
-	}
-
-	credentialDetails := AdapterCredentialDetails{
-		Fields:      bigQueryCredentialFields,
+	return AdapterCredentialDetails{
+		Fields:      fields,
 		Field_Order: []string{},
-	}
-	return credentialDetails, nil
+	}, nil
 }
 
 func (c *Client) UpdateBigQueryCredential(

--- a/pkg/framework/objects/bigquery_credential/data_source.go
+++ b/pkg/framework/objects/bigquery_credential/data_source.go
@@ -100,7 +100,23 @@ func (d *bigqueryCredentialDataSource) Read(
 	state.NumThreads = types.Int64Value(int64(credential.GetThreads()))
 	state.IsActive = types.BoolValue(credential.State == dbt_cloud.STATE_ACTIVE)
 	state.ProjectID = types.Int64Value(int64(credential.Project_Id))
-
+	// WIF fields (v1 only; null when not set)
+	if v := credential.GetAuthType(); v != "" {
+		state.AuthType = types.StringValue(v)
+	} else {
+		state.AuthType = types.StringNull()
+	}
+	if v := credential.GetWorkloadPoolProviderPath(); v != "" {
+		state.WorkloadPoolProviderPath = types.StringValue(v)
+	} else {
+		state.WorkloadPoolProviderPath = types.StringNull()
+	}
+	if v := credential.GetServiceAccountImpersonationURL(); v != "" {
+		state.ServiceAccountImpersonationURL = types.StringValue(v)
+	} else {
+		state.ServiceAccountImpersonationURL = types.StringNull()
+	}
+	
 	// Set state
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/pkg/framework/objects/bigquery_credential/data_source.go
+++ b/pkg/framework/objects/bigquery_credential/data_source.go
@@ -116,7 +116,7 @@ func (d *bigqueryCredentialDataSource) Read(
 	} else {
 		state.ServiceAccountImpersonationURL = types.StringNull()
 	}
-	
+
 	// Set state
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/pkg/framework/objects/bigquery_credential/data_source.go
+++ b/pkg/framework/objects/bigquery_credential/data_source.go
@@ -100,22 +100,10 @@ func (d *bigqueryCredentialDataSource) Read(
 	state.NumThreads = types.Int64Value(int64(credential.GetThreads()))
 	state.IsActive = types.BoolValue(credential.State == dbt_cloud.STATE_ACTIVE)
 	state.ProjectID = types.Int64Value(int64(credential.Project_Id))
-	// WIF fields (v1 only; null when not set)
-	if v := credential.GetAuthType(); v != "" {
-		state.AuthType = types.StringValue(v)
-	} else {
-		state.AuthType = types.StringNull()
-	}
-	if v := credential.GetWorkloadPoolProviderPath(); v != "" {
-		state.WorkloadPoolProviderPath = types.StringValue(v)
-	} else {
-		state.WorkloadPoolProviderPath = types.StringNull()
-	}
-	if v := credential.GetServiceAccountImpersonationURL(); v != "" {
-		state.ServiceAccountImpersonationURL = types.StringValue(v)
-	} else {
-		state.ServiceAccountImpersonationURL = types.StringNull()
-	}
+	// WIF fields, v1 only
+	state.AuthType = optionalString(credential.GetAuthType())
+	state.WorkloadPoolProviderPath = optionalString(credential.GetWorkloadPoolProviderPath())
+	state.ServiceAccountImpersonationURL = optionalString(credential.GetServiceAccountImpersonationURL())
 
 	// Set state
 	diags = resp.State.Set(ctx, &state)

--- a/pkg/framework/objects/bigquery_credential/model.go
+++ b/pkg/framework/objects/bigquery_credential/model.go
@@ -6,21 +6,27 @@ import (
 
 // BigqueryCredentialResourceModel is the model for the resource
 type BigqueryCredentialResourceModel struct {
-	ID           types.String `tfsdk:"id"`
-	CredentialID types.Int64  `tfsdk:"credential_id"`
-	ProjectID    types.Int64  `tfsdk:"project_id"`
-	IsActive     types.Bool   `tfsdk:"is_active"`
-	Dataset      types.String `tfsdk:"dataset"`
-	NumThreads   types.Int64  `tfsdk:"num_threads"`
-	ConnectionID types.Int64  `tfsdk:"connection_id"`
+	ID                             types.String `tfsdk:"id"`
+	CredentialID                   types.Int64  `tfsdk:"credential_id"`
+	ProjectID                      types.Int64  `tfsdk:"project_id"`
+	IsActive                       types.Bool   `tfsdk:"is_active"`
+	Dataset                        types.String `tfsdk:"dataset"`
+	NumThreads                     types.Int64  `tfsdk:"num_threads"`
+	ConnectionID                   types.Int64  `tfsdk:"connection_id"`
+	AuthType                       types.String `tfsdk:"auth_type"`
+	WorkloadPoolProviderPath       types.String `tfsdk:"workload_pool_provider_path"`
+	ServiceAccountImpersonationURL types.String `tfsdk:"service_account_impersonation_url"`
 }
 
 // BigqueryCredentialDataSourceModel is the model for the data source
 type BigqueryCredentialDataSourceModel struct {
-	ID           types.String `tfsdk:"id"`
-	CredentialID types.Int64  `tfsdk:"credential_id"`
-	ProjectID    types.Int64  `tfsdk:"project_id"`
-	IsActive     types.Bool   `tfsdk:"is_active"`
-	Dataset      types.String `tfsdk:"dataset"`
-	NumThreads   types.Int64  `tfsdk:"num_threads"`
+	ID                             types.String `tfsdk:"id"`
+	CredentialID                   types.Int64  `tfsdk:"credential_id"`
+	ProjectID                      types.Int64  `tfsdk:"project_id"`
+	IsActive                       types.Bool   `tfsdk:"is_active"`
+	Dataset                        types.String `tfsdk:"dataset"`
+	NumThreads                     types.Int64  `tfsdk:"num_threads"`
+	AuthType                       types.String `tfsdk:"auth_type"`
+	WorkloadPoolProviderPath       types.String `tfsdk:"workload_pool_provider_path"`
+	ServiceAccountImpersonationURL types.String `tfsdk:"service_account_impersonation_url"`
 }

--- a/pkg/framework/objects/bigquery_credential/model.go
+++ b/pkg/framework/objects/bigquery_credential/model.go
@@ -18,6 +18,17 @@ type BigqueryCredentialResourceModel struct {
 	ServiceAccountImpersonationURL types.String `tfsdk:"service_account_impersonation_url"`
 }
 
+// SemanticLayerCredentialModel is the model matching SemanticLayerAttributes
+type SemanticLayerCredentialModel struct {
+	ID           types.String `tfsdk:"id"`
+	CredentialID types.Int64  `tfsdk:"credential_id"`
+	ProjectID    types.Int64  `tfsdk:"project_id"`
+	IsActive     types.Bool   `tfsdk:"is_active"`
+	Dataset      types.String `tfsdk:"dataset"`
+	NumThreads   types.Int64  `tfsdk:"num_threads"`
+	ConnectionID types.Int64  `tfsdk:"connection_id"`
+}
+
 // BigqueryCredentialDataSourceModel is the model for the data source
 type BigqueryCredentialDataSourceModel struct {
 	ID                             types.String `tfsdk:"id"`

--- a/pkg/framework/objects/bigquery_credential/resource.go
+++ b/pkg/framework/objects/bigquery_credential/resource.go
@@ -136,6 +136,30 @@ func (r *bigqueryCredentialResource) Create(
 		adapterVersion = connection.Data.AdapterVersion
 	}
 
+	// A connection_id on its own doesn't guarantee the v1 adapter, and the WIF fields don't
+	// exist on v0 credentials
+	latestAdapterVersion := dbt_cloud.BigQueryConfig{}.LatestAdapterVersion()
+	if adapterVersion != latestAdapterVersion {
+		for _, field := range wifFields(plan) {
+			if field.value.IsNull() || field.value.IsUnknown() {
+				continue
+			}
+			resp.Diagnostics.AddAttributeError(
+				path.Root(field.name),
+				"Unsupported Field for the Connection Adapter",
+				fmt.Sprintf(
+					"The field '%s' is only supported for %s credentials, but the connection uses '%s'. Set `use_latest_adapter = true` on the connection to use it.",
+					field.name,
+					latestAdapterVersion,
+					adapterVersion,
+				),
+			)
+		}
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Create new credential
 	credential, err := r.client.CreateBigQueryCredential(
 		projectID,

--- a/pkg/framework/objects/bigquery_credential/resource.go
+++ b/pkg/framework/objects/bigquery_credential/resource.go
@@ -159,6 +159,9 @@ func (r *bigqueryCredentialResource) Create(
 	// Map response body to schema and populate computed values
 	plan.ID = types.StringValue(fmt.Sprintf("%d:%d", projectID, *credential.ID))
 	plan.CredentialID = types.Int64Value(int64(*credential.ID))
+	if plan.AuthType.IsUnknown() {
+		plan.AuthType = optionalString(credential.GetAuthType())
+	}
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)
@@ -207,22 +210,10 @@ func (r *bigqueryCredentialResource) Read(
 	state.Dataset = types.StringValue(credential.GetDataset())
 	state.NumThreads = types.Int64Value(int64(credential.GetThreads()))
 
-	// WIF fields (v1 only; null when not set to avoid perpetual diffs)
-	if v := credential.GetAuthType(); v != "" {
-		state.AuthType = types.StringValue(v)
-	} else {
-		state.AuthType = types.StringNull()
-	}
-	if v := credential.GetWorkloadPoolProviderPath(); v != "" {
-		state.WorkloadPoolProviderPath = types.StringValue(v)
-	} else {
-		state.WorkloadPoolProviderPath = types.StringNull()
-	}
-	if v := credential.GetServiceAccountImpersonationURL(); v != "" {
-		state.ServiceAccountImpersonationURL = types.StringValue(v)
-	} else {
-		state.ServiceAccountImpersonationURL = types.StringNull()
-	}
+	// WIF fields, v1 only
+	state.AuthType = optionalString(credential.GetAuthType())
+	state.WorkloadPoolProviderPath = optionalString(credential.GetWorkloadPoolProviderPath())
+	state.ServiceAccountImpersonationURL = optionalString(credential.GetServiceAccountImpersonationURL())
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)

--- a/pkg/framework/objects/bigquery_credential/resource.go
+++ b/pkg/framework/objects/bigquery_credential/resource.go
@@ -15,9 +15,10 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &bigqueryCredentialResource{}
-	_ resource.ResourceWithConfigure   = &bigqueryCredentialResource{}
-	_ resource.ResourceWithImportState = &bigqueryCredentialResource{}
+	_ resource.Resource                   = &bigqueryCredentialResource{}
+	_ resource.ResourceWithConfigure      = &bigqueryCredentialResource{}
+	_ resource.ResourceWithImportState    = &bigqueryCredentialResource{}
+	_ resource.ResourceWithValidateConfig = &bigqueryCredentialResource{}
 )
 
 // BigqueryCredentialResource is a helper function to simplify the provider implementation.
@@ -71,6 +72,31 @@ func (r *bigqueryCredentialResource) Schema(
 	resp *resource.SchemaResponse,
 ) {
 	resp.Schema = BigQueryResourceSchema
+}
+
+// ValidateConfig checks the cross-field requirements of the WIF authentication method.
+func (r *bigqueryCredentialResource) ValidateConfig(
+	ctx context.Context,
+	req resource.ValidateConfigRequest,
+	resp *resource.ValidateConfigResponse,
+) {
+	var config BigqueryCredentialResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.AuthType.ValueString() == AuthTypeExternalOAuthWIF &&
+		config.WorkloadPoolProviderPath.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("workload_pool_provider_path"),
+			"Missing Required Field for External OAuth WIF",
+			fmt.Sprintf(
+				"When auth_type is '%s', the field 'workload_pool_provider_path' must be specified.",
+				AuthTypeExternalOAuthWIF,
+			),
+		)
+	}
 }
 
 // Create creates the resource and sets the initial Terraform state.

--- a/pkg/framework/objects/bigquery_credential/resource.go
+++ b/pkg/framework/objects/bigquery_credential/resource.go
@@ -91,6 +91,9 @@ func (r *bigqueryCredentialResource) Create(
 	projectID := int(plan.ProjectID.ValueInt64())
 	dataset := plan.Dataset.ValueString()
 	numThreads := int(plan.NumThreads.ValueInt64())
+	authType := plan.AuthType.ValueString()
+	workloadPoolProviderPath := plan.WorkloadPoolProviderPath.ValueString()
+	serviceAccountImpersonationURL := plan.ServiceAccountImpersonationURL.ValueString()
 
 	// Auto-detect adapter version from the connection if connection_id is provided
 	var adapterVersion string
@@ -115,6 +118,9 @@ func (r *bigqueryCredentialResource) Create(
 		dataset,
 		numThreads,
 		adapterVersion,
+		authType,
+		workloadPoolProviderPath,
+		serviceAccountImpersonationURL,
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -174,6 +180,23 @@ func (r *bigqueryCredentialResource) Read(
 	// Use helper methods to get dataset and threads from the correct location (v0 vs v1)
 	state.Dataset = types.StringValue(credential.GetDataset())
 	state.NumThreads = types.Int64Value(int64(credential.GetThreads()))
+
+	// WIF fields (v1 only; null when not set to avoid perpetual diffs)
+	if v := credential.GetAuthType(); v != "" {
+		state.AuthType = types.StringValue(v)
+	} else {
+		state.AuthType = types.StringNull()
+	}
+	if v := credential.GetWorkloadPoolProviderPath(); v != "" {
+		state.WorkloadPoolProviderPath = types.StringValue(v)
+	} else {
+		state.WorkloadPoolProviderPath = types.StringNull()
+	}
+	if v := credential.GetServiceAccountImpersonationURL(); v != "" {
+		state.ServiceAccountImpersonationURL = types.StringValue(v)
+	} else {
+		state.ServiceAccountImpersonationURL = types.StringNull()
+	}
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)

--- a/pkg/framework/objects/bigquery_credential/resource_acceptance_test.go
+++ b/pkg/framework/objects/bigquery_credential/resource_acceptance_test.go
@@ -247,3 +247,172 @@ resource "dbtcloud_bigquery_credential" "test_credential_legacy" {
 }
 `, projectName, dataset)
 }
+
+// TestAccDbtCloudBigQueryCredentialResourceWIF tests that a v1 credential using the
+// external-oauth-wif auth type sends and reads back the WIF fields, both on the resource
+// after a refresh and on the data source.
+func TestAccDbtCloudBigQueryCredentialResourceWIF(t *testing.T) {
+	projectNameWIF := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	datasetWIF := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	connectionNameWIF := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	workloadPoolProviderPath := "projects/123456/locations/global/workloadIdentityPools/test-pool/providers/test-provider"
+	serviceAccountImpersonationURL := "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/test@test-gcp-project.iam.gserviceaccount.com:generateAccessToken"
+
+	checkWIFFields := resource.ComposeAggregateTestCheckFunc(
+		testAccCheckDbtCloudBigQueryCredentialExists(
+			"dbtcloud_bigquery_credential.test_credential_wif",
+		),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_bigquery_credential.test_credential_wif",
+			"auth_type",
+			"external-oauth-wif",
+		),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_bigquery_credential.test_credential_wif",
+			"workload_pool_provider_path",
+			workloadPoolProviderPath,
+		),
+		resource.TestCheckResourceAttr(
+			"dbtcloud_bigquery_credential.test_credential_wif",
+			"service_account_impersonation_url",
+			serviceAccountImpersonationURL,
+		),
+		resource.TestCheckResourceAttr(
+			"data.dbtcloud_bigquery_credential.test_credential_wif",
+			"auth_type",
+			"external-oauth-wif",
+		),
+		resource.TestCheckResourceAttr(
+			"data.dbtcloud_bigquery_credential.test_credential_wif",
+			"workload_pool_provider_path",
+			workloadPoolProviderPath,
+		),
+		resource.TestCheckResourceAttr(
+			"data.dbtcloud_bigquery_credential.test_credential_wif",
+			"service_account_impersonation_url",
+			serviceAccountImpersonationURL,
+		),
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudBigQueryCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDbtCloudBigQueryCredentialResourceWIFConfig(
+					projectNameWIF,
+					datasetWIF,
+					connectionNameWIF,
+					workloadPoolProviderPath,
+					serviceAccountImpersonationURL,
+				),
+				Check: checkWIFFields,
+			},
+			// REFRESH, to check that the WIF fields read back from the API match the config
+			{
+				RefreshState: true,
+				Check:        checkWIFFields,
+			},
+		},
+	})
+}
+
+func testAccDbtCloudBigQueryCredentialResourceWIFConfig(
+	projectName, dataset, connectionName, workloadPoolProviderPath, serviceAccountImpersonationURL string,
+) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_project" "test_project" {
+  name = "%s"
+}
+
+resource "dbtcloud_global_connection" "test_connection" {
+  name = "%s"
+
+  bigquery = {
+    gcp_project_id              = "test-gcp-project"
+    application_id              = "oauth_application_id"
+    application_secret          = "oauth_secret_id"
+    deployment_env_auth_type    = "external-oauth-wif"
+    use_latest_adapter          = true
+    private_key_id              = "my-private-key-id"
+    private_key                 = "ABCDEFGHIJKL"
+    client_email                = "test@test-gcp-project.iam.gserviceaccount.com"
+    client_id                   = "123456789"
+    auth_uri                    = "https://accounts.google.com/o/oauth2/auth"
+    token_uri                   = "https://oauth2.googleapis.com/token"
+    auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
+    client_x509_cert_url        = "https://www.googleapis.com/robot/v1/metadata/x509/test"
+  }
+}
+
+resource "dbtcloud_bigquery_credential" "test_credential_wif" {
+  is_active                         = true
+  project_id                        = dbtcloud_project.test_project.id
+  dataset                           = "%s"
+  num_threads                       = 4
+  connection_id                     = dbtcloud_global_connection.test_connection.id
+  auth_type                         = "external-oauth-wif"
+  workload_pool_provider_path       = "%s"
+  service_account_impersonation_url = "%s"
+}
+
+data "dbtcloud_bigquery_credential" "test_credential_wif" {
+  project_id    = dbtcloud_project.test_project.id
+  credential_id = dbtcloud_bigquery_credential.test_credential_wif.credential_id
+}
+`, projectName, connectionName, dataset, workloadPoolProviderPath, serviceAccountImpersonationURL)
+}
+
+// TestAccDbtCloudBigQueryCredentialResourceWIFValidation tests that the v1-only fields are
+// rejected at plan time when they are incomplete or used without a connection.
+func TestAccDbtCloudBigQueryCredentialResourceWIFValidation(t *testing.T) {
+	projectNameInvalid := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	datasetInvalid := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// external-oauth-wif without workload_pool_provider_path
+			{
+				Config: testAccDbtCloudBigQueryCredentialResourceInvalidWIFConfig(
+					projectNameInvalid,
+					datasetInvalid,
+					`connection_id = 12345
+  auth_type     = "external-oauth-wif"`,
+				),
+				ExpectError: regexp.MustCompile("Missing Required Field for External OAuth WIF"),
+			},
+			// v1-only fields without connection_id
+			{
+				Config: testAccDbtCloudBigQueryCredentialResourceInvalidWIFConfig(
+					projectNameInvalid,
+					datasetInvalid,
+					`auth_type                   = "external-oauth-wif"
+  workload_pool_provider_path = "projects/123456/locations/global/workloadIdentityPools/test-pool/providers/test-provider"`,
+				),
+				ExpectError: regexp.MustCompile("Invalid Attribute Combination"),
+			},
+		},
+	})
+}
+
+func testAccDbtCloudBigQueryCredentialResourceInvalidWIFConfig(
+	projectName, dataset, credentialFields string,
+) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_project" "test_project" {
+  name = "%s"
+}
+
+resource "dbtcloud_bigquery_credential" "test_credential_invalid" {
+  is_active   = true
+  project_id  = dbtcloud_project.test_project.id
+  dataset     = "%s"
+  num_threads = 4
+  %s
+}
+`, projectName, dataset, credentialFields)
+}

--- a/pkg/framework/objects/bigquery_credential/resource_acceptance_test.go
+++ b/pkg/framework/objects/bigquery_credential/resource_acceptance_test.go
@@ -416,3 +416,63 @@ resource "dbtcloud_bigquery_credential" "test_credential_invalid" {
 }
 `, projectName, dataset, credentialFields)
 }
+
+// TestAccDbtCloudBigQueryCredentialResourceWIFOnV0Connection tests that the v1-only fields
+// are rejected when connection_id points to a connection using the legacy adapter.
+func TestAccDbtCloudBigQueryCredentialResourceWIFOnV0Connection(t *testing.T) {
+	projectNameV0 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	datasetV0 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	connectionNameV0 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDbtCloudBigQueryCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDbtCloudBigQueryCredentialResourceWIFOnV0ConnectionConfig(
+					projectNameV0,
+					datasetV0,
+					connectionNameV0,
+				),
+				ExpectError: regexp.MustCompile("only supported for bigquery_v1 credentials"),
+			},
+		},
+	})
+}
+
+func testAccDbtCloudBigQueryCredentialResourceWIFOnV0ConnectionConfig(
+	projectName, dataset, connectionName string,
+) string {
+	return fmt.Sprintf(`
+resource "dbtcloud_project" "test_project" {
+  name = "%s"
+}
+
+resource "dbtcloud_global_connection" "test_connection" {
+  name = "%s"
+
+  bigquery = {
+    gcp_project_id              = "test-gcp-project"
+    private_key_id              = "my-private-key-id"
+    private_key                 = "ABCDEFGHIJKL"
+    client_email                = "test@test-gcp-project.iam.gserviceaccount.com"
+    client_id                   = "123456789"
+    auth_uri                    = "https://accounts.google.com/o/oauth2/auth"
+    token_uri                   = "https://oauth2.googleapis.com/token"
+    auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
+    client_x509_cert_url        = "https://www.googleapis.com/robot/v1/metadata/x509/test"
+  }
+}
+
+resource "dbtcloud_bigquery_credential" "test_credential_v0" {
+  is_active                   = true
+  project_id                  = dbtcloud_project.test_project.id
+  dataset                     = "%s"
+  num_threads                 = 4
+  connection_id               = dbtcloud_global_connection.test_connection.id
+  auth_type                   = "external-oauth-wif"
+  workload_pool_provider_path = "projects/123456/locations/global/workloadIdentityPools/test-pool/providers/test-provider"
+}
+`, projectName, connectionName, dataset)
+}

--- a/pkg/framework/objects/bigquery_credential/resource_unit_test.go
+++ b/pkg/framework/objects/bigquery_credential/resource_unit_test.go
@@ -1,0 +1,179 @@
+package bigquery_credential_test
+
+import (
+	"context"
+	"testing"
+
+	bqcredential "github.com/dbt-labs/terraform-provider-dbtcloud/pkg/framework/objects/bigquery_credential"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func credentialAttributeTypes() map[string]tftypes.Type {
+	return map[string]tftypes.Type{
+		"id":                                tftypes.String,
+		"is_active":                         tftypes.Bool,
+		"project_id":                        tftypes.Number,
+		"credential_id":                     tftypes.Number,
+		"dataset":                           tftypes.String,
+		"num_threads":                       tftypes.Number,
+		"connection_id":                     tftypes.Number,
+		"auth_type":                         tftypes.String,
+		"workload_pool_provider_path":       tftypes.String,
+		"service_account_impersonation_url": tftypes.String,
+	}
+}
+
+func credentialConfig(connectionID, authType, workloadPoolProviderPath tftypes.Value) tfsdk.Config {
+	raw := tftypes.NewValue(
+		tftypes.Object{AttributeTypes: credentialAttributeTypes()},
+		map[string]tftypes.Value{
+			"id":                                tftypes.NewValue(tftypes.String, nil),
+			"is_active":                         tftypes.NewValue(tftypes.Bool, true),
+			"project_id":                        tftypes.NewValue(tftypes.Number, 123),
+			"credential_id":                     tftypes.NewValue(tftypes.Number, nil),
+			"dataset":                           tftypes.NewValue(tftypes.String, "my_dataset"),
+			"num_threads":                       tftypes.NewValue(tftypes.Number, 4),
+			"connection_id":                     connectionID,
+			"auth_type":                         authType,
+			"workload_pool_provider_path":       workloadPoolProviderPath,
+			"service_account_impersonation_url": tftypes.NewValue(tftypes.String, nil),
+		},
+	)
+	return tfsdk.Config{Schema: bqcredential.BigQueryResourceSchema, Raw: raw}
+}
+
+func runCredentialValidateConfig(t *testing.T, cfg tfsdk.Config) *resource.ValidateConfigResponse {
+	t.Helper()
+	r, ok := bqcredential.BigqueryCredentialResource().(resource.ResourceWithValidateConfig)
+	if !ok {
+		t.Fatal("bigquery credential resource does not implement ResourceWithValidateConfig")
+	}
+	resp := &resource.ValidateConfigResponse{}
+	r.ValidateConfig(context.Background(), resource.ValidateConfigRequest{Config: cfg}, resp)
+	return resp
+}
+
+func runCredentialAttributeValidators(
+	t *testing.T,
+	cfg tfsdk.Config,
+	name string,
+	value string,
+) *validator.StringResponse {
+	t.Helper()
+	attribute, ok := bqcredential.BigQueryResourceSchema.Attributes[name].(resource_schema.StringAttribute)
+	if !ok {
+		t.Fatalf("%s is not a string attribute", name)
+	}
+
+	req := validator.StringRequest{
+		Path:           path.Root(name),
+		PathExpression: path.MatchRoot(name),
+		Config:         cfg,
+		ConfigValue:    types.StringValue(value),
+	}
+	resp := &validator.StringResponse{}
+	for _, v := range attribute.Validators {
+		v.ValidateString(context.Background(), req, resp)
+	}
+	return resp
+}
+
+func TestBigQueryCredentialValidateConfig_WIFWithoutWorkloadPoolProviderPath(t *testing.T) {
+	t.Parallel()
+	resp := runCredentialValidateConfig(t, credentialConfig(
+		tftypes.NewValue(tftypes.Number, 456),
+		tftypes.NewValue(tftypes.String, "external-oauth-wif"),
+		tftypes.NewValue(tftypes.String, nil),
+	))
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error for missing workload_pool_provider_path with external-oauth-wif")
+	}
+}
+
+func TestBigQueryCredentialValidateConfig_WIFWithWorkloadPoolProviderPath(t *testing.T) {
+	t.Parallel()
+	resp := runCredentialValidateConfig(t, credentialConfig(
+		tftypes.NewValue(tftypes.Number, 456),
+		tftypes.NewValue(tftypes.String, "external-oauth-wif"),
+		tftypes.NewValue(tftypes.String, "projects/1/locations/global/workloadIdentityPools/p/providers/pr"),
+	))
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors, got: %s", resp.Diagnostics.Errors())
+	}
+}
+
+func TestBigQueryCredentialValidateConfig_UnknownWorkloadPoolProviderPath(t *testing.T) {
+	t.Parallel()
+	resp := runCredentialValidateConfig(t, credentialConfig(
+		tftypes.NewValue(tftypes.Number, 456),
+		tftypes.NewValue(tftypes.String, "external-oauth-wif"),
+		tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	))
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected unknown values to be deferred to apply, got: %s", resp.Diagnostics.Errors())
+	}
+}
+
+func TestBigQueryCredentialValidateConfig_ServiceAccountJSONWithoutWIFFields(t *testing.T) {
+	t.Parallel()
+	resp := runCredentialValidateConfig(t, credentialConfig(
+		tftypes.NewValue(tftypes.Number, 456),
+		tftypes.NewValue(tftypes.String, "service-account-json"),
+		tftypes.NewValue(tftypes.String, nil),
+	))
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors, got: %s", resp.Diagnostics.Errors())
+	}
+}
+
+func TestBigQueryCredentialWIFAttributes_RequireConnectionID(t *testing.T) {
+	t.Parallel()
+
+	withoutConnection := credentialConfig(
+		tftypes.NewValue(tftypes.Number, nil),
+		tftypes.NewValue(tftypes.String, "external-oauth-wif"),
+		tftypes.NewValue(tftypes.String, "projects/1/locations/global/workloadIdentityPools/p/providers/pr"),
+	)
+	withConnection := credentialConfig(
+		tftypes.NewValue(tftypes.Number, 456),
+		tftypes.NewValue(tftypes.String, "external-oauth-wif"),
+		tftypes.NewValue(tftypes.String, "projects/1/locations/global/workloadIdentityPools/p/providers/pr"),
+	)
+
+	for name, value := range map[string]string{
+		"auth_type":                         "external-oauth-wif",
+		"workload_pool_provider_path":       "projects/1/locations/global/workloadIdentityPools/p/providers/pr",
+		"service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/svc:generateAccessToken",
+	} {
+		if resp := runCredentialAttributeValidators(t, withoutConnection, name, value); !resp.Diagnostics.HasError() {
+			t.Errorf("expected error for %s without connection_id", name)
+		}
+		if resp := runCredentialAttributeValidators(t, withConnection, name, value); resp.Diagnostics.HasError() {
+			t.Errorf("expected no errors for %s with connection_id, got: %s", name, resp.Diagnostics.Errors())
+		}
+	}
+}
+
+// The Semantic Layer credential resource reuses these attributes and its API does not
+// accept the v1 WIF fields, so they must not leak into its schema.
+func TestBigQueryCredentialSemanticLayerAttributes_ExcludeWIFFields(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{
+		"auth_type",
+		"workload_pool_provider_path",
+		"service_account_impersonation_url",
+	} {
+		if _, ok := bqcredential.SemanticLayerAttributes[name]; ok {
+			t.Errorf("%s should not be part of the Semantic Layer credential attributes", name)
+		}
+		if _, ok := bqcredential.BigQueryResourceSchema.Attributes[name]; !ok {
+			t.Errorf("%s should be part of the BigQuery credential resource schema", name)
+		}
+	}
+}

--- a/pkg/framework/objects/bigquery_credential/schema.go
+++ b/pkg/framework/objects/bigquery_credential/schema.go
@@ -2,6 +2,7 @@ package bigquery_credential
 
 import (
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	datasource_schema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -62,6 +63,9 @@ var BigQueryResourceSchema = resource_schema.Schema{
 		"auth_type": resource_schema.StringAttribute{
 			Optional:    true,
 			Description: "The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
+			Validators: []validator.String{
+				stringvalidator.OneOf(AuthTypes...),
+			},
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},

--- a/pkg/framework/objects/bigquery_credential/schema.go
+++ b/pkg/framework/objects/bigquery_credential/schema.go
@@ -59,6 +59,27 @@ var BigQueryResourceSchema = resource_schema.Schema{
 				int64planmodifier.RequiresReplace(),
 			},
 		},
+		"auth_type": resource_schema.StringAttribute{
+			Optional:    true,
+			Description: "The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"workload_pool_provider_path": resource_schema.StringAttribute{
+			Optional:    true,
+			Description: "The fully specified resource name of the workload pool provider, required when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"service_account_impersonation_url": resource_schema.StringAttribute{
+			Optional:    true,
+			Description: "The URL for the service account impersonation request, used when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
 	},
 }
 
@@ -88,6 +109,18 @@ var datasourceSchema = datasource_schema.Schema{
 		"num_threads": datasource_schema.Int64Attribute{
 			Computed:    true,
 			Description: "Number of threads to use",
+		},
+		"auth_type": datasource_schema.StringAttribute{
+			Computed:    true,
+			Description: "The authentication method for the BigQuery credential",
+		},
+		"workload_pool_provider_path": datasource_schema.StringAttribute{
+			Computed:    true,
+			Description: "The fully specified resource name of the workload pool provider",
+		},
+		"service_account_impersonation_url": datasource_schema.StringAttribute{
+			Computed:    true,
+			Description: "The URL for the service account impersonation request",
 		},
 	},
 }

--- a/pkg/framework/objects/bigquery_credential/schema.go
+++ b/pkg/framework/objects/bigquery_credential/schema.go
@@ -74,14 +74,17 @@ var BigQueryResourceSchema = resource_schema.Schema{
 func resourceAttributes() map[string]resource_schema.Attribute {
 	attributes := maps.Clone(SemanticLayerAttributes)
 
+	// Computed because the API defaults it to `service-account-json` for v1 credentials
 	attributes["auth_type"] = resource_schema.StringAttribute{
 		Optional:    true,
+		Computed:    true,
 		Description: "The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
 		Validators: []validator.String{
 			stringvalidator.OneOf(AuthTypes...),
 			stringvalidator.AlsoRequires(path.MatchRoot("connection_id")),
 		},
 		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
 			stringplanmodifier.RequiresReplace(),
 		},
 	}

--- a/pkg/framework/objects/bigquery_credential/schema.go
+++ b/pkg/framework/objects/bigquery_credential/schema.go
@@ -1,9 +1,12 @@
 package bigquery_credential
 
 import (
+	"maps"
+
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/helper"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	datasource_schema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
@@ -12,79 +15,100 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-var BigQueryResourceSchema = resource_schema.Schema{
-	Description: "Bigquery credential resource",
-	Attributes: map[string]resource_schema.Attribute{
-		"id": resource_schema.StringAttribute{
-			Computed:    true,
-			Description: "The ID of this resource. Contains the project ID and the credential ID.",
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
-			},
-		},
-		"is_active": resource_schema.BoolAttribute{
-			Computed:    true,
-			Optional:    true,
-			Default:     booldefault.StaticBool(true),
-			Description: "Whether the BigQuery credential is active",
-		},
-		"project_id": resource_schema.Int64Attribute{
-			Required:    true,
-			Description: "Project ID to create the BigQuery credential in",
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.RequiresReplace(),
-			},
-		},
-		"credential_id": resource_schema.Int64Attribute{
-			Computed:    true,
-			Description: "The internal credential ID",
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.UseStateForUnknown(),
-			},
-		},
-		"dataset": resource_schema.StringAttribute{
-			Required:    true,
-			Description: "Default dataset name",
-			Validators: []validator.String{
-				helper.SchemaNameValidator(),
-			},
-		},
-		"num_threads": resource_schema.Int64Attribute{
-			Required:    true,
-			Description: "Number of threads to use",
-		},
-		"connection_id": resource_schema.Int64Attribute{
-			Optional:    true,
-			Description: "The ID of the global connection to use for this credential. When provided, the credential will automatically use the correct adapter version based on the connection's configuration (e.g., bigquery_v1 for connections with use_latest_adapter=true).",
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.RequiresReplace(),
-			},
-		},
-		"auth_type": resource_schema.StringAttribute{
-			Optional:    true,
-			Description: "The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
-			Validators: []validator.String{
-				stringvalidator.OneOf(AuthTypes...),
-			},
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
-			},
-		},
-		"workload_pool_provider_path": resource_schema.StringAttribute{
-			Optional:    true,
-			Description: "The fully specified resource name of the workload pool provider, required when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
-			},
-		},
-		"service_account_impersonation_url": resource_schema.StringAttribute{
-			Optional:    true,
-			Description: "The URL for the service account impersonation request, used when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
-			},
+// SemanticLayerAttributes are the credential attributes shared with the Semantic Layer
+// credential resource. The v1 WIF attributes are not part of it, as the Semantic Layer
+// credential API does not accept them.
+var SemanticLayerAttributes = map[string]resource_schema.Attribute{
+	"id": resource_schema.StringAttribute{
+		Computed:    true,
+		Description: "The ID of this resource. Contains the project ID and the credential ID.",
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
 		},
 	},
+	"is_active": resource_schema.BoolAttribute{
+		Computed:    true,
+		Optional:    true,
+		Default:     booldefault.StaticBool(true),
+		Description: "Whether the BigQuery credential is active",
+	},
+	"project_id": resource_schema.Int64Attribute{
+		Required:    true,
+		Description: "Project ID to create the BigQuery credential in",
+		PlanModifiers: []planmodifier.Int64{
+			int64planmodifier.RequiresReplace(),
+		},
+	},
+	"credential_id": resource_schema.Int64Attribute{
+		Computed:    true,
+		Description: "The internal credential ID",
+		PlanModifiers: []planmodifier.Int64{
+			int64planmodifier.UseStateForUnknown(),
+		},
+	},
+	"dataset": resource_schema.StringAttribute{
+		Required:    true,
+		Description: "Default dataset name",
+		Validators: []validator.String{
+			helper.SchemaNameValidator(),
+		},
+	},
+	"num_threads": resource_schema.Int64Attribute{
+		Required:    true,
+		Description: "Number of threads to use",
+	},
+	"connection_id": resource_schema.Int64Attribute{
+		Optional:    true,
+		Description: "The ID of the global connection to use for this credential. When provided, the credential will automatically use the correct adapter version based on the connection's configuration (e.g., bigquery_v1 for connections with use_latest_adapter=true).",
+		PlanModifiers: []planmodifier.Int64{
+			int64planmodifier.RequiresReplace(),
+		},
+	},
+}
+
+var BigQueryResourceSchema = resource_schema.Schema{
+	Description: "Bigquery credential resource",
+	Attributes:  resourceAttributes(),
+}
+
+func resourceAttributes() map[string]resource_schema.Attribute {
+	attributes := maps.Clone(SemanticLayerAttributes)
+
+	attributes["auth_type"] = resource_schema.StringAttribute{
+		Optional:    true,
+		Description: "The authentication method for the BigQuery credential. Supported values: `service-account-json`, `oauth-secrets`, `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
+		Validators: []validator.String{
+			stringvalidator.OneOf(AuthTypes...),
+			stringvalidator.AlsoRequires(path.MatchRoot("connection_id")),
+		},
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.RequiresReplace(),
+		},
+	}
+	attributes["workload_pool_provider_path"] = resource_schema.StringAttribute{
+		Optional:    true,
+		Description: "The fully specified resource name of the workload pool provider, required when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
+		Validators: []validator.String{
+			stringvalidator.LengthAtLeast(1),
+			stringvalidator.AlsoRequires(path.MatchRoot("connection_id")),
+		},
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.RequiresReplace(),
+		},
+	}
+	attributes["service_account_impersonation_url"] = resource_schema.StringAttribute{
+		Optional:    true,
+		Description: "The URL for the service account impersonation request, used when `auth_type` is `external-oauth-wif`. Only applicable for v1 credentials (when `connection_id` is set).",
+		Validators: []validator.String{
+			stringvalidator.LengthAtLeast(1),
+			stringvalidator.AlsoRequires(path.MatchRoot("connection_id")),
+		},
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.RequiresReplace(),
+		},
+	}
+
+	return attributes
 }
 
 var datasourceSchema = datasource_schema.Schema{

--- a/pkg/framework/objects/bigquery_credential/utils.go
+++ b/pkg/framework/objects/bigquery_credential/utils.go
@@ -1,5 +1,7 @@
 package bigquery_credential
 
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
 const (
 	AuthTypeServiceAccountJSON = "service-account-json"
 	AuthTypeOAuthSecrets       = "oauth-secrets"
@@ -10,4 +12,13 @@ var AuthTypes = []string{
 	AuthTypeServiceAccountJSON,
 	AuthTypeOAuthSecrets,
 	AuthTypeExternalOAuthWIF,
+}
+
+// optionalString maps an empty API value to null, so that fields the API does not return
+// don't show up as an empty string in state
+func optionalString(value string) types.String {
+	if value == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(value)
 }

--- a/pkg/framework/objects/bigquery_credential/utils.go
+++ b/pkg/framework/objects/bigquery_credential/utils.go
@@ -1,0 +1,7 @@
+package bigquery_credential
+
+var AuthTypes = []string{
+	"service-account-json",
+	"oauth-secrets",
+	"external-oauth-wif",
+}

--- a/pkg/framework/objects/bigquery_credential/utils.go
+++ b/pkg/framework/objects/bigquery_credential/utils.go
@@ -22,3 +22,17 @@ func optionalString(value string) types.String {
 	}
 	return types.StringValue(value)
 }
+
+type wifField struct {
+	name  string
+	value types.String
+}
+
+// wifFields returns the v1-only WIF attributes, in schema order
+func wifFields(model BigqueryCredentialResourceModel) []wifField {
+	return []wifField{
+		{"auth_type", model.AuthType},
+		{"workload_pool_provider_path", model.WorkloadPoolProviderPath},
+		{"service_account_impersonation_url", model.ServiceAccountImpersonationURL},
+	}
+}

--- a/pkg/framework/objects/bigquery_credential/utils.go
+++ b/pkg/framework/objects/bigquery_credential/utils.go
@@ -1,7 +1,13 @@
 package bigquery_credential
 
+const (
+	AuthTypeServiceAccountJSON = "service-account-json"
+	AuthTypeOAuthSecrets       = "oauth-secrets"
+	AuthTypeExternalOAuthWIF   = "external-oauth-wif"
+)
+
 var AuthTypes = []string{
-	"service-account-json",
-	"oauth-secrets",
-	"external-oauth-wif",
+	AuthTypeServiceAccountJSON,
+	AuthTypeOAuthSecrets,
+	AuthTypeExternalOAuthWIF,
 }

--- a/pkg/framework/objects/global_connection/common.go
+++ b/pkg/framework/objects/global_connection/common.go
@@ -712,6 +712,18 @@ func readGeneric(
 		state.Name = types.StringPointerValue(common.Name)
 		state.IsSshTunnelEnabled = types.BoolPointerValue(common.IsSshTunnelEnabled)
 
+		// nullable common fields
+		if !common.PrivateLinkEndpointId.IsNull() {
+			state.PrivateLinkEndpointId = types.StringValue(common.PrivateLinkEndpointId.MustGet())
+		} else {
+			state.PrivateLinkEndpointId = types.StringNull()
+		}
+		if !common.OauthConfigurationId.IsNull() {
+			state.OauthConfigurationId = types.Int64Value(common.OauthConfigurationId.MustGet())
+		} else {
+			state.OauthConfigurationId = types.Int64Null()
+		}
+
 		// Teradata settings
 		state.TeradataConfig.Host = types.StringPointerValue(teradataCfg.Host)
 		state.TeradataConfig.Port = types.StringPointerValue(teradataCfg.Port)

--- a/pkg/framework/objects/global_connection/data_source.go
+++ b/pkg/framework/objects/global_connection/data_source.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/dbt-labs/terraform-provider-dbtcloud/pkg/dbt_cloud"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var (
@@ -62,6 +63,14 @@ func (d *globalConnectionDataSource) Read(
 		)
 		resp.State.RemoveResource(ctx)
 		return
+	}
+
+	// readGeneric can't infer this one: the API only reports the adapter version, so
+	// the resource carries `use_latest_adapter` over from its own state instead
+	if newState.BigQueryConfig != nil {
+		newState.BigQueryConfig.UseLatestAdapter = types.BoolValue(
+			globalConnectionResponse.Data.AdapterVersion == dbt_cloud.BigQueryConfig{}.LatestAdapterVersion(),
+		)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)

--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -2175,3 +2175,109 @@ resource dbtcloud_global_connection test {
 
 `, connectionName, jobExecutionTimeoutSeconds)
 }
+
+// TestAccDbtCloudGlobalConnectionBigQueryOAuthConfiguration tests that
+// oauth_configuration_id can be set on a BigQuery connection, is read back from the API
+// and can be removed again.
+func TestAccDbtCloudGlobalConnectionBigQueryOAuthConfiguration(t *testing.T) {
+	connectionName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest_helper.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// create with oauth_configuration_id
+			{
+				Config: testAccDbtCloudGlobalConnectionBigQueryOAuthConfigurationConfig(
+					connectionName,
+					true,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"dbtcloud_global_connection.test",
+						"adapter_version",
+						"bigquery_v1",
+					),
+					resource.TestCheckResourceAttrPair(
+						"dbtcloud_global_connection.test",
+						"oauth_configuration_id",
+						"dbtcloud_oauth_configuration.test",
+						"id",
+					),
+				),
+			},
+			// IMPORT, to check that oauth_configuration_id is read back
+			{
+				ResourceName:      "dbtcloud_global_connection.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bigquery.private_key",
+					"bigquery.application_secret",
+					"bigquery.application_id",
+					"bigquery.use_latest_adapter",
+					"bigquery.deployment_env_auth_type",
+				},
+			},
+			// modify, removing oauth_configuration_id
+			{
+				Config: testAccDbtCloudGlobalConnectionBigQueryOAuthConfigurationConfig(
+					connectionName,
+					false,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(
+						"dbtcloud_global_connection.test",
+						"oauth_configuration_id",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDbtCloudGlobalConnectionBigQueryOAuthConfigurationConfig(
+	connectionName string,
+	withOAuthConfiguration bool,
+) string {
+	oauthConfigurationID := ""
+	if withOAuthConfiguration {
+		oauthConfigurationID = "oauth_configuration_id = dbtcloud_oauth_configuration.test.id"
+	}
+
+	return fmt.Sprintf(`
+
+resource dbtcloud_oauth_configuration test {
+  type = "entra"
+  name = "OAuth config"
+  client_secret = "secret"
+  client_id = "myid2"
+  redirect_uri = "http://example.com"
+  token_url = "http://example.com"
+  authorize_url = "http://example.com"
+  application_id_uri = "app-uri"
+}
+
+resource dbtcloud_global_connection test {
+  name = "%s"
+  %s
+
+  bigquery = {
+    gcp_project_id              = "my-gcp-project-id"
+    application_id              = "oauth_application_id"
+    application_secret          = "oauth_secret_id"
+    deployment_env_auth_type    = "external-oauth-wif"
+    use_latest_adapter          = true
+    private_key_id              = "placeholder"
+    private_key                 = "placeholder"
+    client_email                = "placeholder@example.com"
+    client_id                   = "placeholder"
+    auth_uri                    = "https://accounts.google.com/o/oauth2/auth"
+    token_uri                   = "https://oauth2.googleapis.com/token"
+    auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
+    client_x509_cert_url        = "https://www.googleapis.com/robot/v1/metadata/x509/placeholder"
+  }
+}
+
+`, connectionName, oauthConfigurationID)
+}

--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -2181,6 +2181,8 @@ resource dbtcloud_global_connection test {
 // and can be removed again.
 func TestAccDbtCloudGlobalConnectionBigQueryOAuthConfiguration(t *testing.T) {
 	connectionName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	// the OAuth client ID has to be unique across the account
+	oAuthClientID := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
@@ -2190,6 +2192,7 @@ func TestAccDbtCloudGlobalConnectionBigQueryOAuthConfiguration(t *testing.T) {
 			{
 				Config: testAccDbtCloudGlobalConnectionBigQueryOAuthConfigurationConfig(
 					connectionName,
+					oAuthClientID,
 					true,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -2223,6 +2226,7 @@ func TestAccDbtCloudGlobalConnectionBigQueryOAuthConfiguration(t *testing.T) {
 			{
 				Config: testAccDbtCloudGlobalConnectionBigQueryOAuthConfigurationConfig(
 					connectionName,
+					oAuthClientID,
 					false,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -2238,6 +2242,7 @@ func TestAccDbtCloudGlobalConnectionBigQueryOAuthConfiguration(t *testing.T) {
 
 func testAccDbtCloudGlobalConnectionBigQueryOAuthConfigurationConfig(
 	connectionName string,
+	oAuthClientID string,
 	withOAuthConfiguration bool,
 ) string {
 	oauthConfigurationID := ""
@@ -2249,9 +2254,9 @@ func testAccDbtCloudGlobalConnectionBigQueryOAuthConfigurationConfig(
 
 resource dbtcloud_oauth_configuration test {
   type = "entra"
-  name = "OAuth config"
+  name = "OAuth config %s"
   client_secret = "secret"
-  client_id = "myid2"
+  client_id = "%s"
   redirect_uri = "http://example.com"
   token_url = "http://example.com"
   authorize_url = "http://example.com"
@@ -2279,5 +2284,5 @@ resource dbtcloud_global_connection test {
   }
 }
 
-`, connectionName, oauthConfigurationID)
+`, oAuthClientID, oAuthClientID, connectionName, oauthConfigurationID)
 }

--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -16,6 +16,7 @@ func TestAccDbtCloudGlobalConnectionSnowflakeResource(t *testing.T) {
 	connectionName2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	oAuthClientID := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	oAuthClientSecret := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	// the OAuth configuration client ID has to be unique across the account
 	oAuthConfigurationClientID := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -2219,6 +2220,7 @@ func TestAccDbtCloudGlobalConnectionBigQueryOAuthConfiguration(t *testing.T) {
 					"bigquery.application_secret",
 					"bigquery.application_id",
 					"bigquery.use_latest_adapter",
+					"bigquery.timeout_seconds",
 					"bigquery.deployment_env_auth_type",
 				},
 			},

--- a/pkg/framework/objects/global_connection/schema.go
+++ b/pkg/framework/objects/global_connection/schema.go
@@ -59,7 +59,7 @@ func (r *globalConnectionResource) Schema(
 			},
 			"oauth_configuration_id": resource_schema.Int64Attribute{
 				Optional:    true,
-				Description: "External OAuth configuration ID (only Snowflake for now)",
+				Description: "External OAuth configuration ID. Supported for all connection types.",
 			},
 			"bigquery": resource_schema.SingleNestedAttribute{
 				Optional: true,

--- a/pkg/framework/objects/global_connection/schema.go
+++ b/pkg/framework/objects/global_connection/schema.go
@@ -689,6 +689,10 @@ func (r *globalConnectionDataSource) Schema(
 						Computed:    true,
 						Description: "Timeout in seconds for queries",
 					},
+					"job_execution_timeout_seconds": datasource_schema.Int64Attribute{
+						Computed:    true,
+						Description: "Timeout in seconds for job execution, used by the bigquery_v1 adapter",
+					},
 					"private_key_id": datasource_schema.StringAttribute{
 						Computed:    true,
 						Description: "Private Key ID for the Service Account",
@@ -780,6 +784,10 @@ func (r *globalConnectionDataSource) Schema(
 						Computed:    true,
 						ElementType: types.StringType,
 						Description: "OAuth scopes for the BigQuery connection",
+					},
+					"use_latest_adapter": datasource_schema.BoolAttribute{
+						Computed:    true,
+						Description: "Whether the connection uses the latest bigquery_v1 adapter (used for BQ WIF)",
 					},
 					"deployment_env_auth_type": datasource_schema.StringAttribute{
 						Computed:    true,

--- a/pkg/framework/objects/semantic_layer_credential/model.go
+++ b/pkg/framework/objects/semantic_layer_credential/model.go
@@ -23,20 +23,20 @@ type SnowflakeSLCredentialModel struct {
 }
 
 type BigQuerySLCredentialModel struct {
-	ID                  types.Int64                                         `tfsdk:"id"`
-	Configuration       SemanticLayerConfigurationModel                     `tfsdk:"configuration"`
-	Credential          bigquery_credential.BigqueryCredentialResourceModel `tfsdk:"credential"`
-	PrivateKeyID        types.String                                        `tfsdk:"private_key_id"`
-	PrivateKey          types.String                                        `tfsdk:"private_key"`
-	PrivateKeyWo        types.String                                        `tfsdk:"private_key_wo"`
-	PrivateKeyWoVersion types.Int64                                         `tfsdk:"private_key_wo_version"`
-	ClientEmail         types.String                                        `tfsdk:"client_email"`
-	ClientID            types.String                                        `tfsdk:"client_id"`
-	AuthURI             types.String                                        `tfsdk:"auth_uri"`
-	TokenURI            types.String                                        `tfsdk:"token_uri"`
-	AuthProviderCertURL types.String                                        `tfsdk:"auth_provider_x509_cert_url"`
-	ClientCertURL       types.String                                        `tfsdk:"client_x509_cert_url"`
-	ExecutionProject    types.String                                        `tfsdk:"execution_project"`
+	ID                  types.Int64                                      `tfsdk:"id"`
+	Configuration       SemanticLayerConfigurationModel                  `tfsdk:"configuration"`
+	Credential          bigquery_credential.SemanticLayerCredentialModel `tfsdk:"credential"`
+	PrivateKeyID        types.String                                     `tfsdk:"private_key_id"`
+	PrivateKey          types.String                                     `tfsdk:"private_key"`
+	PrivateKeyWo        types.String                                     `tfsdk:"private_key_wo"`
+	PrivateKeyWoVersion types.Int64                                      `tfsdk:"private_key_wo_version"`
+	ClientEmail         types.String                                     `tfsdk:"client_email"`
+	ClientID            types.String                                     `tfsdk:"client_id"`
+	AuthURI             types.String                                     `tfsdk:"auth_uri"`
+	TokenURI            types.String                                     `tfsdk:"token_uri"`
+	AuthProviderCertURL types.String                                     `tfsdk:"auth_provider_x509_cert_url"`
+	ClientCertURL       types.String                                     `tfsdk:"client_x509_cert_url"`
+	ExecutionProject    types.String                                     `tfsdk:"execution_project"`
 }
 
 type RedshiftSLCredentialModel struct {
@@ -52,7 +52,7 @@ type DatabricksSLCredentialModel struct {
 }
 
 type PostgresSLCredentialModel struct {
-	ID            types.Int64                                             `tfsdk:"id"`
-	Configuration SemanticLayerConfigurationModel                         `tfsdk:"configuration"`
-	Credential    postgres_credential.PostgresCredentialResourceModel 	  `tfsdk:"credential"`
+	ID            types.Int64                                         `tfsdk:"id"`
+	Configuration SemanticLayerConfigurationModel                     `tfsdk:"configuration"`
+	Credential    postgres_credential.PostgresCredentialResourceModel `tfsdk:"credential"`
 }

--- a/pkg/framework/objects/semantic_layer_credential/schema.go
+++ b/pkg/framework/objects/semantic_layer_credential/schema.go
@@ -68,7 +68,7 @@ var bigquery_sl_credential_resource_schema = resource_schema.Schema{
 		"credential": resource_schema.SingleNestedAttribute{
 			Required:    true,
 			Description: "BigQuery credential details, but used in the context of the Semantic Layer.",
-			Attributes:  bigquery_credential.BigQueryResourceSchema.Attributes,
+			Attributes:  bigquery_credential.SemanticLayerAttributes,
 		},
 
 		"private_key_id": resource_schema.StringAttribute{


### PR DESCRIPTION
## Summary

2. **`dbtcloud_bigquery_credential`** — adds the fields needed for BigQuery Workload Identity Federation (WIF). Resolves #706.
3. **`dbtcloud_global_connection`** — `oauth_configuration_id` is now usable for all connection types (not just Snowflake). Resolves #705.

---

### 2. Add BigQuery WIF fields to `bigquery_credential` (#706)

`dbtcloud_bigquery_credential` was missing the fields required to create a credential that uses Workload Identity Federation, so WIF-based setups couldn't be fully managed in Terraform. Adds:

- `auth_type` — `service-account-json`, `oauth-secrets`, or `external-oauth-wif`
- `workload_pool_provider_path` — required when `auth_type` is `external-oauth-wif`
- `service_account_impersonation_url` — used with `external-oauth-wif`

These apply to v1 credentials (when `connection_id` is set) and are exposed on both the resource and the data source.

**Files**
- `pkg/dbt_cloud/bigquery_credential.go`
- `pkg/framework/objects/bigquery_credential/{model,schema,resource,data_source}.go`

### 3. Support `oauth_configuration_id` for all connection types in `global_connection` (#705)

`oauth_configuration_id` was documented and wired up for Snowflake only, which blocked BigQuery WIF global connections from linking their OAuth integration. The attribute now applies to all connection types, and the generic read path populates the nullable common fields (`oauth_configuration_id`, `private_link_endpoint_id`) so they round-trip correctly.

**Files**
- `pkg/framework/objects/global_connection/schema.go`
- `pkg/framework/objects/global_connection/common.go`

---

### Testing

- `go build ./...` and `go vet ./...`
- Acceptance tests for the affected resources (`TF_ACC=1`)

### Related issues

- Resolves #705
- Resolves #706
