### PR TITLE
fix acceptance test flakiness

### DIFF
--- a/.changes/unreleased/Behind the scenes-20260904-111914.yaml
+++ b/.changes/unreleased/Behind the scenes-20260904-111914.yaml
@@ -1,0 +1,3 @@
+kind: Behind the scenes
+body: change github runners
+time: 2026-09-04T11:19:14.768129+03:00

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   daily-tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -56,7 +56,7 @@ jobs:
   unit:
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     needs: check-changie
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'cloud-tests' || '' }}
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.target == 'test-acceptance' || github.ref }}

--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -16,6 +16,7 @@ func TestAccDbtCloudGlobalConnectionSnowflakeResource(t *testing.T) {
 	connectionName2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	oAuthClientID := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	oAuthClientSecret := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	oAuthConfigurationClientID := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest_helper.TestAccPreCheck(t) },
@@ -27,6 +28,7 @@ func TestAccDbtCloudGlobalConnectionSnowflakeResource(t *testing.T) {
 					connectionName,
 					oAuthClientID,
 					oAuthClientSecret,
+					oAuthConfigurationClientID,
 				),
 				// we check the computed values, for the other ones the test suite already checks that the plan and state are the same
 				Check: resource.ComposeTestCheckFunc(
@@ -50,6 +52,7 @@ func TestAccDbtCloudGlobalConnectionSnowflakeResource(t *testing.T) {
 			{
 				Config: testAccDbtCloudSGlobalConnectionSnowflakeResourceFullConfig(
 					connectionName,
+					oAuthConfigurationClientID,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
@@ -78,6 +81,7 @@ func TestAccDbtCloudGlobalConnectionSnowflakeResource(t *testing.T) {
 					connectionName2,
 					oAuthClientID,
 					oAuthClientSecret,
+					oAuthConfigurationClientID,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
@@ -112,15 +116,15 @@ func TestAccDbtCloudGlobalConnectionSnowflakeResource(t *testing.T) {
 }
 
 func testAccDbtCloudSGlobalConnectionSnowflakeResourceBasicConfig(
-	connectionName, oAuthClientID, oAuthClientSecret string,
+	connectionName, oAuthClientID, oAuthClientSecret, oAuthConfigurationClientID string,
 ) string {
 	return fmt.Sprintf(`
 
 resource dbtcloud_oauth_configuration test {
   type = "entra"
-  name = "OAuth config"
+  name = "OAuth config %s"
   client_secret = "secret"
-  client_id = "myid2"
+  client_id = "%s"
   redirect_uri = "http://example.com"
   token_url = "http://example.com"
   authorize_url = "http://example.com"
@@ -142,19 +146,19 @@ resource dbtcloud_global_connection test {
   }
 }
 
-`, connectionName, oAuthClientID, oAuthClientSecret)
+`, oAuthConfigurationClientID, oAuthConfigurationClientID, connectionName, oAuthClientID, oAuthClientSecret)
 }
 
 func testAccDbtCloudSGlobalConnectionSnowflakeResourceFullConfig(
-	connectionName string,
+	connectionName, oAuthConfigurationClientID string,
 ) string {
 	return fmt.Sprintf(`
 
 resource dbtcloud_oauth_configuration test {
   type = "entra"
-  name = "OAuth config"
+  name = "OAuth config %s"
   client_secret = "secret"
-  client_id = "myid2"
+  client_id = "%s"
   redirect_uri = "http://example.com"
   token_url = "http://example.com"
   authorize_url = "http://example.com"
@@ -177,7 +181,7 @@ resource dbtcloud_global_connection test {
 	role = "role"
   }
 }
-`, connectionName)
+`, oAuthConfigurationClientID, oAuthConfigurationClientID, connectionName)
 }
 
 func TestAccDbtCloudGlobalConnectionBigQueryResource(t *testing.T) {


### PR DESCRIPTION
- run the test jobs on Depot, which removes the network failures the GitHub-hosted runners hit against the API
- randomize the Snowflake test's OAuth configuration client id, which has to be unique per account, so a leftover from an earlier run no longer fails every later one