### PR TITLE
feat(global_connection): add scopes field to databricks schema in glo…

### DIFF
--- a/.changes/unreleased/Changes-20260910-125340.yaml
+++ b/.changes/unreleased/Changes-20260910-125340.yaml
@@ -1,0 +1,3 @@
+kind: Changes
+body: add scopes to databricks nested schema in global_connection resource
+time: 2026-09-10T12:53:40.147198-05:00

--- a/docs/data-sources/global_connection.md
+++ b/docs/data-sources/global_connection.md
@@ -127,6 +127,7 @@ Read-Only:
 - `client_secret` (String) Required to enable Databricks OAuth authentication for IDE developers.
 - `host` (String) The hostname of the Databricks cluster or SQL warehouse.
 - `http_path` (String) The HTTP path of the Databricks cluster or SQL warehouse.
+- `scopes` (Set of String) OAuth scopes to use for the Databricks connection (e.g. `sql`, `all-apis`). When not set, dbt Cloud relies on the default scopes (`all-apis` and `offline_access`).
 
 
 <a id="nestedatt--fabric"></a>

--- a/docs/resources/global_connection.md
+++ b/docs/resources/global_connection.md
@@ -297,6 +297,7 @@ Optional:
 - `catalog` (String) Catalog name if Unity Catalog is enabled in your Databricks workspace.
 - `client_id` (String) Required to enable Databricks OAuth authentication for IDE developers.
 - `client_secret` (String) Required to enable Databricks OAuth authentication for IDE developers.
+- `scopes` (Set of String) OAuth scopes to use for the Databricks connection (e.g. `sql`, `all-apis`). When not set, dbt Cloud relies on the default scopes (`all-apis` and `offline_access`).
 
 
 <a id="nestedatt--fabric"></a>

--- a/pkg/dbt_cloud/global_connection.go
+++ b/pkg/dbt_cloud/global_connection.go
@@ -448,11 +448,12 @@ func (BigQueryConfig) AdapterVersion() string {
 }
 
 type DatabricksConfig struct {
-	Host         *string                   `json:"host,omitempty"`
-	HTTPPath     *string                   `json:"http_path,omitempty"`
-	Catalog      nullable.Nullable[string] `json:"catalog,omitempty"`
-	ClientID     nullable.Nullable[string] `json:"client_id,omitempty"`
-	ClientSecret nullable.Nullable[string] `json:"client_secret,omitempty"`
+	Host         *string                     `json:"host,omitempty"`
+	HTTPPath     *string                     `json:"http_path,omitempty"`
+	Catalog      nullable.Nullable[string]   `json:"catalog,omitempty"`
+	ClientID     nullable.Nullable[string]   `json:"client_id,omitempty"`
+	ClientSecret nullable.Nullable[string]   `json:"client_secret,omitempty"`
+	Scopes       nullable.Nullable[[]string] `json:"scopes,omitempty"`
 }
 
 func (DatabricksConfig) AdapterVersion() string {

--- a/pkg/framework/objects/global_connection/common.go
+++ b/pkg/framework/objects/global_connection/common.go
@@ -266,6 +266,14 @@ func readGeneric(
 			state.DatabricksConfig.Catalog = types.StringNull()
 		}
 
+		if !databricksCfg.Scopes.IsNull() {
+			state.DatabricksConfig.Scopes = helper.SliceStringToSliceTypesString(
+				databricksCfg.Scopes.MustGet(),
+			)
+		} else {
+			state.DatabricksConfig.Scopes = nil
+		}
+
 		// We don't set the sensitive fields when we read because those are secret and never returned by the API
 		// sensitive fields: ClientID, ClientSecret
 

--- a/pkg/framework/objects/global_connection/model.go
+++ b/pkg/framework/objects/global_connection/model.go
@@ -208,9 +208,10 @@ type DatabricksConfig struct {
 	Host     types.String `tfsdk:"host"`
 	HTTPPath types.String `tfsdk:"http_path"`
 	// nullable
-	Catalog      types.String `tfsdk:"catalog"`
-	ClientID     types.String `tfsdk:"client_id"`
-	ClientSecret types.String `tfsdk:"client_secret"`
+	Catalog      types.String   `tfsdk:"catalog"`
+	ClientID     types.String   `tfsdk:"client_id"`
+	ClientSecret types.String   `tfsdk:"client_secret"`
+	Scopes       []types.String `tfsdk:"scopes"`
 }
 
 type RedshiftConfig struct {

--- a/pkg/framework/objects/global_connection/resource.go
+++ b/pkg/framework/objects/global_connection/resource.go
@@ -351,6 +351,11 @@ func (r *globalConnectionResource) Create(
 		if !plan.DatabricksConfig.ClientSecret.IsNull() {
 			databricksCfg.ClientSecret.Set(plan.DatabricksConfig.ClientSecret.ValueString())
 		}
+		if len(plan.DatabricksConfig.Scopes) > 0 {
+			databricksCfg.Scopes.Set(
+				helper.TypesStringSliceToStringSlice(plan.DatabricksConfig.Scopes),
+			)
+		}
 
 		commonResp, _, err := c.Create(commonCfg, databricksCfg)
 
@@ -1090,6 +1095,17 @@ func (r *globalConnectionResource) Update(
 				warehouseConfigChanges.ClientSecret.SetNull()
 			} else {
 				warehouseConfigChanges.ClientSecret.Set(plan.DatabricksConfig.ClientSecret.ValueString())
+			}
+		}
+
+		left, right := lo.Difference(plan.DatabricksConfig.Scopes, state.DatabricksConfig.Scopes)
+		if len(left) > 0 || len(right) > 0 {
+			if len(plan.DatabricksConfig.Scopes) == 0 {
+				warehouseConfigChanges.Scopes.SetNull()
+			} else {
+				warehouseConfigChanges.Scopes.Set(
+					helper.TypesStringSliceToStringSlice(plan.DatabricksConfig.Scopes),
+				)
 			}
 		}
 

--- a/pkg/framework/objects/global_connection/resource_acceptance_test.go
+++ b/pkg/framework/objects/global_connection/resource_acceptance_test.go
@@ -850,6 +850,10 @@ func TestAccDbtCloudGlobalConnectionDatabricksResource(t *testing.T) {
 						"is_ssh_tunnel_enabled",
 						"false",
 					),
+					resource.TestCheckNoResourceAttr(
+						"dbtcloud_global_connection.test",
+						"databricks.scopes",
+					),
 				),
 			},
 			// modify, adding optional fields
@@ -874,6 +878,21 @@ func TestAccDbtCloudGlobalConnectionDatabricksResource(t *testing.T) {
 						"is_ssh_tunnel_enabled",
 						"false",
 					),
+					resource.TestCheckResourceAttr(
+						"dbtcloud_global_connection.test",
+						"databricks.scopes.#",
+						"2",
+					),
+					resource.TestCheckTypeSetElemAttr(
+						"dbtcloud_global_connection.test",
+						"databricks.scopes.*",
+						"sql",
+					),
+					resource.TestCheckTypeSetElemAttr(
+						"dbtcloud_global_connection.test",
+						"databricks.scopes.*",
+						"offline_access",
+					),
 				),
 			},
 			// modify, removing optional fields to check PATCH when we remove fields
@@ -895,6 +914,10 @@ func TestAccDbtCloudGlobalConnectionDatabricksResource(t *testing.T) {
 						"dbtcloud_global_connection.test",
 						"is_ssh_tunnel_enabled",
 						"false",
+					),
+					resource.TestCheckNoResourceAttr(
+						"dbtcloud_global_connection.test",
+						"databricks.scopes",
 					),
 				),
 			},
@@ -948,6 +971,7 @@ resource dbtcloud_global_connection test {
 	// catalog = "dbt_catalog"
 	client_id = "%s"
 	client_secret = "%s"
+	scopes = ["sql", "offline_access"]
   }
 }
 `, connectionName, oAuthClientID, oAuthClientSecret)

--- a/pkg/framework/objects/global_connection/schema.go
+++ b/pkg/framework/objects/global_connection/schema.go
@@ -273,6 +273,11 @@ func (r *globalConnectionResource) Schema(
 						Optional:    true,
 						Description: "Required to enable Databricks OAuth authentication for IDE developers.",
 					},
+					"scopes": resource_schema.SetAttribute{
+						Optional:    true,
+						ElementType: types.StringType,
+						Description: "OAuth scopes to use for the Databricks connection (e.g. `sql`, `all-apis`). When not set, dbt Cloud relies on the default scopes (`all-apis` and `offline_access`).",
+					},
 				},
 			},
 			"redshift": resource_schema.SingleNestedAttribute{
@@ -860,6 +865,11 @@ func (r *globalConnectionDataSource) Schema(
 					"client_secret": datasource_schema.StringAttribute{
 						Computed:    true,
 						Description: "Required to enable Databricks OAuth authentication for IDE developers.",
+					},
+					"scopes": datasource_schema.SetAttribute{
+						Computed:    true,
+						ElementType: types.StringType,
+						Description: "OAuth scopes to use for the Databricks connection (e.g. `sql`, `all-apis`). When not set, dbt Cloud relies on the default scopes (`all-apis` and `offline_access`).",
 					},
 				},
 			},


### PR DESCRIPTION
Resolves #742

We support a `scopes` field on Databricks global connections via API-only (no UI support), confirmed via dbt-rust-sdk:

```
dbtp account-connections create --json-body-template | jq '.definitions.DatabricksConnection'

{
  "properties": {
    "adapter_id": {
      "format": "int64",
      "type": [
        "integer",
        "null"
      ]
    },
    "catalog": {
      "default": "",
      "type": "string"
    },
    "client_id": {
      "type": [
        "string",
        "null"
      ]
    },
    "client_secret": {
      "type": [
        "string",
        "null"
      ]
    },
    "host": {
      "type": "string"
    },
    "http_path": {
      "type": "string"
    },
    "scopes": {
      "items": {
        "type": "string"
      },
      "type": "array"
    }
  },
  "required": [
    "host",
    "http_path"
  ],
  "type": "object"
}
```

So, this PR:

- Adds an optional `scopes` field to the databricks block of `dbtcloud_global_connection`, mirroring the field already supported for bigquery.
- dbt Cloud added support for passing scopes on Databricks connections in dbt-labs/dbt-cloud#15021 (https://github.com/dbt-labs/dbt-cloud/pull/15021) to let users configure which OAuth scopes (`sql`, `all-apis`, etc.) to request, instead of always defaulting to `all-apis` + `offline_access`. This surfaces that field in the provider.
- Unlike BigQuery's scopes (which has a static default and is Optional+Computed), Databricks' scopes is a true nullable field with no default (None on the API side). The provider now sends explicit null on update when the field is removed from config, and omits it entirely on create when unset, so dbt Cloud falls back to its default scopes.

Verified against an internal PS sandbox dbt account that POST/PATCH/GET round-trip scopes correctly, including sending explicit null to unset it.

Tests and changelog included!